### PR TITLE
Load/save snapshots

### DIFF
--- a/coffee/core/core.coffee
+++ b/coffee/core/core.coffee
@@ -37,6 +37,9 @@ class LC.LiterallyCanvas
       backgroundImage.onload = => @repaint()
       @saveShape(new LC.ImageShape(0, 0, backgroundImage, true))
 
+    @loadSnapshotJSON(@opts.loadSnapshotJSON) if @opts.loadSnapshotJSON
+    @loadSnapshot(@opts.loadSnapshot) if @opts.loadSnapshot
+
     @repaint()
 
   updateSize: =>
@@ -210,7 +213,7 @@ class LC.LiterallyCanvas
   getSnapshotJSON: -> JSON.stringify(@shapes)  # yep, that works
 
   loadSnapshot: (snapshot) ->
-    @shapes = []
+    @shapes = (shape for shape in @shapes when shape.locked)
     @repaint(true)
     for shapeRepr in snapshot
       if shapeRepr.className of LC

--- a/coffee/core/shapes.coffee
+++ b/coffee/core/shapes.coffee
@@ -111,6 +111,7 @@ class LC.LinePathShape extends LC.Shape
     @sampleSize = @tailSize + 1
 
   jsonContent: ->
+    # TODO: make point storage more efficient
     {@order, @segmentSize, @tailSize, @sampleSize, @points}
 
   @fromJSON: (lc, data) ->

--- a/coffee/jquery.coffee
+++ b/coffee/jquery.coffee
@@ -17,6 +17,8 @@ LC.init = (el, opts = {}) ->
   opts.backgroundColor ?= 'rgb(230, 230, 230)'
   opts.imageURLPrefix ?= 'lib/img'
   opts.keyboardShortcuts ?= true
+  opts.loadSnapshot ?= null
+  opts.loadSnapshotJSON ?= null
   opts.preserveCanvasContents ?= false
   opts.sizeToContainer ?= true
   opts.watermarkImageURL ?= null

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,6 +58,7 @@
         $('.literally').literallycanvas({
           backgroundColor: 'transparent',
           imageURLPrefix: '/lib/img',
+          loadSnapshotJSON: localStorage.getItem('drawing'),
           preserveCanvasContents: true,
           watermarkImage: watermarkImage
         });
@@ -65,19 +66,17 @@
         var backgroundImage = new Image()
         backgroundImage.src = backgroundImageURL;
         backgroundImage.onload = function () {lc.repaint(true, false);}
-        lc.saveShape(new LC.ImageShape(0, 0, backgroundImage));
-
-        lc.on('saveShape', function() {
-          localStorage.setItem('drawing', lc.getSnapshotJSON());
-          console.log(
-            "Saved drawing is now " + localStorage.getItem('drawing'));
-        });
-
-        var drawing = localStorage.getItem('drawing');
-        if (drawing) {
-          console.log("Loading stored drawing");
-          lc.loadSnapshotJSON(drawing);
+        if (lc.shapes.length <= 1) {
+          console.log('add image');
+          lc.saveShape(new LC.ImageShape(0, 0, backgroundImage));
         }
+
+        var save = function() {
+          localStorage.setItem('drawing', lc.getSnapshotJSON());
+        };
+        lc.on('saveShape', save);
+        lc.on('undo', save);
+        lc.on('redo', save);
       });
 
       $("#open-image").click(function() {


### PR DESCRIPTION
New opts: `loadSnapshot` (an object) and `loadSnapshotJSON` (a string).

New methods on `LC.LiterallyCanvas`: `getSnapshot()`, `getSnapshotJSON()`, `loadSnapshot()`, `loadSnapshotJSON()`.

See `demo/index.html` for usage.
