### PR TITLE
Adding an event handler for the orientation changing on a mobile device ...

### DIFF
--- a/coffee/jquery.coffee
+++ b/coffee/jquery.coffee
@@ -44,7 +44,7 @@ LC.init = (el, opts = {}) ->
     lc.updateSize()
 
   $el.resize(resize)
-  $(window).resize(resize)
+  $(window).bind('orientationchange resize', resize)
   resize()
 
   if 'onInit' of opts


### PR DESCRIPTION
Hooking in an event handler to catch when a mobile device changes it's orientation. This will allow the application to adjust the .literally div size on the same event and the library will resize the canvas correctly as if you were resizing the window on the desktop.
Tested that this works nicely on an iPad.
