### PR TITLE
First pass at brushes and flow

### DIFF
--- a/coffee/core/core.coffee
+++ b/coffee/core/core.coffee
@@ -9,10 +9,11 @@ class LC.LiterallyCanvas
     LC.bindEvents(this, @canvas, @opts.keyboardShortcuts)
 
     @colors =
-      primary: @opts.primaryColor or '#000'
-      secondary: @opts.secondaryColor or '#fff'
-      background: @opts.backgroundColor or 'transparent'
-    $(@canvas).css('background-color', @colors.background)
+      primary: @opts.primaryColor or {'r': 0, 'g': 0, 'b': 0, 'a': 1}
+      secondary: @opts.secondaryColor or {'r': 255, 'g': 255, 'b': 255, 'a': 1}
+      background: @opts.backgroundColor or {'r': 0, 'g': 0, 'b': 0, 'a': 0}
+    console.log(@opts.backgroundColor)
+    $(@canvas).css('background-color', LC.formatColor(@colors.background))
 
     @watermarkImage = @opts.watermarkImage
     if @watermarkImage and not @watermarkImage.complete
@@ -90,7 +91,7 @@ class LC.LiterallyCanvas
 
   setColor: (name, color) ->
     @colors[name] = color
-    $(@canvas).css('background-color', @colors.background)
+    $(@canvas).css('background-color', LC.formatColor(@colors.background))
     @trigger "#{name}ColorChange", @colors[name]
     @repaint()
 
@@ -136,7 +137,7 @@ class LC.LiterallyCanvas
       @buffer.height = @canvas.height
       @bufferCtx.clearRect(0, 0, @buffer.width, @buffer.height)
       if drawBackground
-        @bufferCtx.fillStyle = @colors.background
+        @bufferCtx.fillStyle = LC.formatColor(@colors.background)
         @bufferCtx.fillRect(0, 0, @buffer.width, @buffer.height)
       if @watermarkImage
         @bufferCtx.drawImage(
@@ -280,3 +281,8 @@ class LC.AddShapeAction
   undo: ->
     @lc.shapes.pop(@ix)
     @lc.repaint()
+
+
+# TODO: move this to file with Color class once it exists
+LC.formatColor = (color) ->
+  return "rgba(#{color.r}, #{color.g}, #{color.b}, #{color.a})"

--- a/coffee/core/math.coffee
+++ b/coffee/core/math.coffee
@@ -79,3 +79,56 @@ LC.scalePositionScalar = (val, viewportSize, oldScale, newScale) ->
   oldSize = viewportSize * oldScale
   newSize = viewportSize * newScale
   return val + (oldSize - newSize) / 2
+
+LC.filter = (points) ->
+  newPoints = [points[0]]
+  i = 1
+  last = 0
+
+  while i < points.length
+    a = points[last]
+    b = points[i]
+
+    # TODO: fix magic number constant
+    if LC.len(LC.diff(a, b)) > 0.75
+      newPoints.push(b)
+      last = i
+
+    i++
+
+  return newPoints
+
+LC.fill = (points) ->
+  newPoints = [points[0]]
+  i = 1
+
+  while i < points.length
+    a = points[i - 1]
+    b = points[i]
+
+    newPoints = newPoints.concat(LC.between(a, b).slice(1))
+    i++
+
+  return newPoints
+
+LC.between = (a, b) ->
+  # TODO: fix magic number constant
+  if LC.len(LC.diff(a, b)) < 0.55
+    return [a, b]
+  else
+    m = mid(a, b)
+    return LC.between(a, m).concat(LC.between(m, b).slice(1))
+
+LC.distribute = (points, iterations) ->
+  newPoints = [points[0]]
+
+  for point, i in points.slice(1, -1) then do (point, i) =>
+    m = mid(points[i], points[i + 2])
+    newPoints.push(m)
+
+  newPoints.push(points[points.length - 1])
+
+  if iterations > 0
+    return LC.distribute(newPoints, iterations - 1)
+  else
+    return newPoints

--- a/coffee/core/toolbar.coffee
+++ b/coffee/core/toolbar.coffee
@@ -67,13 +67,19 @@ class LC.Toolbar
 
   _bindColorPicker: (name, title) ->
     $el = @$el.find(".#{name}-picker")
-    $el.css('background-color', @lc.getColor(name))
+    $el.css('background-color', LC.formatColor(@lc.getColor(name)))
     $el.css('background-position', "0% 0%")
     @lc.on "#{name}ColorChange", (color) =>
-      $el.css('background-color', color)
+      $el.css('background-color', LC.formatColor(color))
 
     LC.makeColorPicker $el, "#{title} color", (c) =>
-      @lc.setColor(name, "rgba(#{c.r}, #{c.g}, #{c.b}, #{c.a})")
+      # TODO: replace this with our own color class
+      @lc.setColor(name, {
+        'r': c.r,
+        'g': c.g,
+        'b': c.b,
+        'a': c.a,
+      })
       $el.css('background-position', "0% #{(1 - c.a) * 100}%")
 
   initColors: ->

--- a/coffee/core/tools.coffee
+++ b/coffee/core/tools.coffee
@@ -69,7 +69,7 @@ class LC.Eraser extends LC.Pencil
   constructor: () ->
     @strokeWidth = 10
 
-  makePoint: (x, y, lc) -> new LC.Point(x, y, @strokeWidth, '#000')
+  makePoint: (x, y, lc) -> new LC.Point(x, y, @strokeWidth, {'r': 0, 'g': 0, 'b': 0, 'a': 1})
   makeShape: -> new LC.EraseLinePathShape(this)
 
 

--- a/coffee/jquery.coffee
+++ b/coffee/jquery.coffee
@@ -2,9 +2,9 @@ window.LC = window.LC ? {}
 
 
 LC.init = (el, opts = {}) ->
-  opts.primaryColor ?= '#000'
-  opts.secondaryColor ?= '#fff'
-  opts.backgroundColor ?= 'transparent'
+  opts.primaryColor ?= {'r': 0, 'g': 0, 'b': 0, 'a': 1}
+  opts.secondaryColor ?= {'r': 255, 'g': 255, 'b': 255, 'a': 1}
+  opts.backgroundColor ?= {'r': 255, 'g': 255, 'b': 255, 'a': 0}
   opts.imageURLPrefix ?= 'lib/img'
   opts.keyboardShortcuts ?= true
   opts.preserveCanvasContents ?= false

--- a/demo/index.html
+++ b/demo/index.html
@@ -62,7 +62,7 @@
 
         // the only LC-specific thing we have to do
         $('.literally').literallycanvas({
-          backgroundColor: 'transparent',
+          backgroundColor: {'r': 0, 'g': 0, 'b': 0, 'a': 0},
           imageURLPrefix: '/lib/img',
           // preserveCanvasContents: true,
           watermarkImage: watermarkImage,


### PR DESCRIPTION
This is slow.
This is a hack.
This is partially incorrect.
But it's a start.

If you select the pencil tool and do anything but 100% opacity you will see flow instead of global alpha. Setting the brush to about 12px and the opacity to about 75% looks really nice for demo purposes.

When this is merged some follow up tickets need to be opened:

Make brushes work with JSON import/export.
Importing and exporting still work, but the brush information is simply ignored. Right now we only have one brush so it doesn't really matter.

Fix the distribution algorithm.
For flow to work we need a set of points that are evenly distributed. The current solution gets really close, but still isn't quite right (you may notice the opacity of the line pulses a little). It also relies on several magic numbers.

Implement bitmap caching for flow.
While using flow is inherently slower than drawing polygons, it is much easier to build a caching layer around. Once this is done it should actually be faster than the polygon based solution we currently use.

Create our own Color class.
This needs structured data to fiddle with alpha, so we need to build a color class. For this branch I used a dict with rgba values, but I have a real color class coming down the pipe with the new color picker.
