### PR TITLE
Added canvasForDraw()

### DIFF
--- a/coffee/core/core.coffee
+++ b/coffee/core/core.coffee
@@ -219,6 +219,9 @@ class LC.LiterallyCanvas
       "rgb(#{pixel[0]}, #{pixel[1]}, #{pixel[2]})"
     else
       null
+      
+  canvasForDraw: ->
+    @canvas
 
   canvasForExport: ->
     @repaint(true, true)


### PR DESCRIPTION
Fixed issue where using drawImage on lc.canvasForExport showed previously erased or cleared areas.
