### PR TITLE
Remove second repaint after loadSnapshot returns.

### DIFF
--- a/coffee/core/core.coffee
+++ b/coffee/core/core.coffee
@@ -245,7 +245,6 @@ class LC.LiterallyCanvas
 
   loadSnapshotJSON: (str) ->
     @loadSnapshot(JSON.parse(str))
-    @repaint(true)
 
 
 # maybe add checks to these in the future to make sure you never double-undo or


### PR DESCRIPTION
loadSnapshotJSON is calling repaint(true) a second time immediately after the method loadSnapshot calls it.
