### PR TITLE
Make getImage return undefined if there is no region to draw

### DIFF
--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -334,6 +334,10 @@ module.exports = class LiterallyCanvas
   getImage: (opts={}) ->
     # {x, y, width, height}
     opts.rect ?= @getContentBounds()
+
+    if not (opts.rect.width and opts.rect.height)
+      return
+
     opts.scale ?= 1
     opts.scaleDownRetina ?= true
     opts.scale /= @backingScale if opts.scaleDownRetina


### PR DESCRIPTION
So now you can do something like:

``` javascript
var image = lc.getImage();

if (image) {
    window.open(image.toDataURL());
} else {
    alert('No Image to Show');
}
```

The docs need to be updated with this behavior.
