### PR TITLE
Remove code using offsetX/Y

### DIFF
--- a/src/core/bindEvents.coffee
+++ b/src/core/bindEvents.coffee
@@ -6,14 +6,11 @@ coordsForTouchEvent = (el, e) ->
 
 
 position = (el, e) ->
-  if e.offsetX?
-    {left: e.offsetX, top: e.offsetY}
-  else
-    p = el.getBoundingClientRect()
-    {
-      left: e.clientX - p.left,
-      top: e.clientY - p.top,
-    }
+  p = el.getBoundingClientRect()
+  {
+    left: e.clientX - p.left,
+    top: e.clientY - p.top,
+  }
 
 
 buttonIsDown = (e) ->


### PR DESCRIPTION
Always use getBoundingClientRect. Fixes https://github.com/literallycanvas/literallycanvas/issues/222.
