### PR TITLE
Tool pointer events API; fix bugs

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -61,6 +61,7 @@
     <script src="/lib/js/literallycanvas.js"></script>
 
     <script type="text/javascript">
+
       $(document).ready(function() {
         // disable scrolling on touch devices so we can actually draw
         $(document).bind('touchmove', function(e) {
@@ -81,7 +82,7 @@
 
         // the only LC-specific thing we have to do
         var containerOne = document.getElementsByClassName('literally one')[0];
-        var lc = window.lc = LC.init(containerOne, {
+        var lc = LC.init(containerOne, {
           backgroundShapes: [
             LC.createShape(
               'Image', {image: backgroundImage, x: 100, y: 100}),

--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -12,6 +12,11 @@ module.exports = class LiterallyCanvas
   constructor: (@containerEl, opts) ->
     bindEvents(this, @containerEl, opts.keyboardShortcuts)
 
+    @config =
+      zoomMin: opts.zoomMin or 0.2
+      zoomMax: opts.zoomMax or 4.0
+      zoomStep: opts.zoomStep or 0.2
+
     @colors =
       primary: opts.primaryColor or '#000'
       secondary: opts.secondaryColor or '#fff'
@@ -195,8 +200,8 @@ module.exports = class LiterallyCanvas
 
   zoom: (factor) ->
     newScale = @scale + factor
-    newScale = Math.max(newScale, 0.2)
-    newScale = Math.min(newScale, 4.0)
+    newScale = Math.max(newScale, @config.zoomMin)
+    newScale = Math.min(newScale, @config.zoomMax)
     newScale = Math.round(newScale * 100) / 100
     @setZoom(newScale)
 

--- a/src/core/bindEvents.coffee
+++ b/src/core/bindEvents.coffee
@@ -24,13 +24,13 @@ module.exports = bindEvents = (lc, canvas, panWithKeyboard = false) ->
   mouseMoveListener = (e) =>
     e.preventDefault()
     p = position(canvas, e)
-    lc.continue(p.left, p.top)
+    lc.pointerMove(p.left, p.top)
 
   mouseUpListener = (e) =>
     e.preventDefault()
     canvas.onselectstart = -> true # enable selection while dragging
     p = position(canvas, e)
-    lc.end(p.left, p.top)
+    lc.pointerUp(p.left, p.top)
     document.removeEventListener 'mousemove', mouseMoveListener
     document.removeEventListener 'mouseup', mouseUpListener
 
@@ -39,7 +39,7 @@ module.exports = bindEvents = (lc, canvas, panWithKeyboard = false) ->
     e.preventDefault()
     canvas.onselectstart = -> false # disable selection while dragging
     p = position(canvas, e)
-    lc.begin(p.left, p.top)
+    lc.pointerDown(p.left, p.top)
 
     document.addEventListener 'mousemove', mouseMoveListener
     document.addEventListener 'mouseup', mouseUpListener
@@ -47,11 +47,11 @@ module.exports = bindEvents = (lc, canvas, panWithKeyboard = false) ->
 
   touchMoveListener = (e) ->
     e.preventDefault()
-    lc.continue(coordsForTouchEvent(canvas, e)...)
+    lc.pointerMove(coordsForTouchEvent(canvas, e)...)
 
   touchEndListener = (e) ->
     e.preventDefault()
-    lc.end(coordsForTouchEvent(canvas, e)...)
+    lc.pointerUp(coordsForTouchEvent(canvas, e)...)
     document.removeEventListener 'touchmove', touchMoveListener
     document.removeEventListener 'touchend', touchEndListener
     document.removeEventListener 'touchcancel', touchEndListener
@@ -59,12 +59,12 @@ module.exports = bindEvents = (lc, canvas, panWithKeyboard = false) ->
   canvas.addEventListener 'touchstart', (e) ->
     e.preventDefault()
     if e.touches.length == 1
-      lc.begin(coordsForTouchEvent(canvas, e)...)
+      lc.pointerDown(coordsForTouchEvent(canvas, e)...)
       document.addEventListener 'touchmove', touchMoveListener
       document.addEventListener 'touchend', touchEndListener
       document.addEventListener 'touchcancel', touchEndListener
     else
-      lc.continue(coordsForTouchEvent(canvas, e)...)
+      lc.pointerMove(coordsForTouchEvent(canvas, e)...)
 
   if panWithKeyboard
     document.addEventListener 'keydown', (e) ->

--- a/src/core/shapes.coffee
+++ b/src/core/shapes.coffee
@@ -211,6 +211,10 @@ defineShape 'Line',
     @dash = args.dash or null
 
   draw: (ctx) ->
+    if @x1 == @x2 and @y1 == @y2
+      # browser behavior is not consistent for this case.
+      return
+
     ctx.lineWidth = @strokeWidth
     ctx.strokeStyle = @color
     ctx.lineCap = @capStyle

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -51,6 +51,10 @@ init = (el, opts = {}) ->
   opts.watermarkImage ?= null
   opts.watermarkScale ?= 1
 
+  opts.zoomMin ?= 0.2
+  opts.zoomMax ?= 4.0
+  opts.zoomStep ?= 0.2
+
   unless 'tools' of opts
     opts.tools = [
       tools.Pencil,

--- a/src/reactGUI/ZoomButtons.coffee
+++ b/src/reactGUI/ZoomButtons.coffee
@@ -6,8 +6,8 @@ createZoomButtonComponent = (inOrOut) -> React.createClass
 
   getState: -> {
     isEnabled: switch
-      when inOrOut == 'in' then @props.lc.scale < 4.0
-      when inOrOut == 'out' then  @props.lc.scale > 0.2
+      when inOrOut == 'in' then @props.lc.scale < @props.lc.config.zoomMax
+      when inOrOut == 'out' then  @props.lc.scale > @props.lc.config.zoomMin
   }
   getInitialState: -> @getState()
   mixins: [createSetStateOnEventMixin('zoom')]
@@ -23,8 +23,8 @@ createZoomButtonComponent = (inOrOut) -> React.createClass
       'disabled': not @state.isEnabled
     onClick = switch
       when !@state.isEnabled then ->
-      when inOrOut == 'in' then -> lc.zoom(0.2)
-      when inOrOut == 'out' then -> lc.zoom(-0.2)
+      when inOrOut == 'in' then -> lc.zoom(lc.config.zoomStep)
+      when inOrOut == 'out' then -> lc.zoom(-lc.config.zoomStep)
     src = "#{imageURLPrefix}/zoom-#{inOrOut}.png"
     style = {backgroundImage: "url(#{src})"}
 

--- a/src/reactGUI/ZoomButtons.coffee
+++ b/src/reactGUI/ZoomButtons.coffee
@@ -7,7 +7,7 @@ createZoomButtonComponent = (inOrOut) -> React.createClass
   getState: -> {
     isEnabled: switch
       when inOrOut == 'in' then @props.lc.scale < 4.0
-      when inOrOut == 'out' then  @props.lc.scale > 0.6
+      when inOrOut == 'out' then  @props.lc.scale > 0.2
   }
   getInitialState: -> @getState()
   mixins: [createSetStateOnEventMixin('zoom')]

--- a/src/tools/Pan.coffee
+++ b/src/tools/Pan.coffee
@@ -6,12 +6,24 @@ module.exports = class Pan extends Tool
 
   name: 'Pan'
   iconName: 'pan'
+  usesSimpleAPI: false
 
-  begin: (x, y, lc) -> @start = {x, y}
+  didBecomeActive: (lc) ->
+    unsubscribeFuncs = []
+    @unsubscribe = =>
+      for func in unsubscribeFuncs
+        func()
 
-  continue: (x, y, lc) ->
-    lc.pan @start.x - x, @start.y - y
-    lc.repaintAllLayers()
+    unsubscribeFuncs.push lc.on 'pointerdown', ({x, y}) =>
+      @oldPosition = lc.position
+      @pointerStart = {x, y}
 
-  end: (x, y, lc) ->
-    lc.repaintAllLayers()
+    unsubscribeFuncs.push lc.on 'pointerdrag', ({x, y}) =>
+      dp = {
+        x: (x - @pointerStart.x),
+        y: (y - @pointerStart.y)
+      }
+      lc.setPan(@oldPosition.x + dp.x, @oldPosition.y + dp.y)
+
+  willBecomeInactive: (lc) ->
+    @unsubscribe()

--- a/src/tools/base.coffee
+++ b/src/tools/base.coffee
@@ -8,6 +8,8 @@ tools.Tool = class Tool
   # {imageURLPrefix}/{iconName}.png
   iconName: null
 
+  usesSimpleAPI: true
+
   # called when the user starts dragging
   begin: (x, y, lc) ->
 


### PR DESCRIPTION
Fixes #57, #269, and #284.

Tools can set `@usesSimpleAPI = false` to disable the `begin`/`continue`/`end` callbacks and instead get `pointerdown`, `pointermove`, `pointerup`, and `pointerdrag` events. See the pan tool for an example.

The pan tool no longer craps out when you're zoomed out.

You can configure how far in/out you can zoom, and how much the zoom buttons change the zoom value by, using the config options `zoomMin`, `zoomMax`, and `zoomStep`.