### PR TITLE
Modular rendering API

### DIFF
--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -2,6 +2,8 @@ actions = require './actions'
 bindEvents = require './bindEvents'
 math = require './math'
 {createShape, shapeToJSON, JSONToShape} = require './shapes'
+{renderShapeToContext} = require './canvasRenderer'
+{renderShapeToSVG} = require './svgRenderer'
 Pencil = require '../tools/Pencil'
 util = require './util'
 
@@ -254,7 +256,8 @@ module.exports = class LiterallyCanvas
           @clipped (=>
             @transformed (=>
               for shape in @_shapesInProgress
-                shape.drawLatest(@ctx, @bufferCtx)
+                renderShapeToContext(
+                  @ctx, shape, @bufferCtx, {shouldOnlyDrawLatest: true})
             ), @ctx, @bufferCtx
           ), @ctx, @bufferCtx
 
@@ -282,7 +285,8 @@ module.exports = class LiterallyCanvas
     @repaintLayer('main', false)
     @clipped (=>
       @transformed (=>
-        shape.drawLatest(@ctx, @bufferCtx)
+        renderShapeToContext(
+          @ctx, shape, @bufferCtx, {shouldOnlyDrawLatest: true})
       ), @ctx, @bufferCtx
     ), @ctx, @bufferCtx
 
@@ -292,7 +296,7 @@ module.exports = class LiterallyCanvas
     return unless shapes.length
     drawShapes = =>
       for shape in shapes
-        shape.draw(ctx, retryCallback)
+        renderShapeToContext(ctx, shape, {retryCallback})
     @clipped (=> @transformed(drawShapes, ctx)), ctx
 
   # Executes the given function after clipping the canvas to the image size.
@@ -436,8 +440,8 @@ module.exports = class LiterallyCanvas
         <rect width='#{width}' height='#{height}' x='0' y='0'
           fill='#{@colors.background}' />
         <g transform='translate(#{-x}, #{-y})'>
-          #{@backgroundShapes.map((s) -> s.toSVG()).join('')}
-          #{@shapes.map((s) -> s.toSVG()).join('')}
+          #{@backgroundShapes.map(renderShapeToSVG).join('')}
+          #{@shapes.map(renderShapeToSVG).join('')}
         </g>
       </svg>
     ".replace(/(\r\n|\n|\r)/gm,"")

--- a/src/core/canvasRenderer.coffee
+++ b/src/core/canvasRenderer.coffee
@@ -1,0 +1,196 @@
+lineEndCapShapes = require './lineEndCapShapes.coffee'
+renderers = {}
+
+
+# drawFunc(ctx, shape, retryCallback)
+# drawLatest(ctx, bufferCtx, shape, retryCallback)
+defineCanvasRenderer = (shapeName, drawFunc, drawLatestFunc) ->
+	renderers[shapeName] = {drawFunc, drawLatestFunc}
+
+
+noop = ->
+renderShapeToContext = (ctx, shape, opts={}) ->
+  opts.ignoreUnsupportedShapes ?= false
+  opts.retryCallback ?= noop
+  opts.shouldOnlyDrawLatest = false
+  opts.bufferCtx ?= null
+
+  if renderers[shape.className]
+    if opts.shouldOnlyDrawLatest and renderers[shape.className].drawLatest
+      renderers[shape.className].drawLatestFunc(
+        ctx, bufferCtx, shape, opts.retryCallback)
+    else
+      renderers[shape.className].drawFunc(ctx, shape, opts.retryCallback)
+  else if opts.ignoreUnsupportedShapes
+    console.warn "Can't render shape of type #{shape.className}"
+  else
+    throw "Can't render shape of type #{shape.className}"
+
+
+renderShapeToCanvas = (canvas, shape, opts) ->
+  renderShapeToContext(canvas.getContext('2d'), shape, opts)
+
+
+###
+defineCanvasRenderer 'Rectangle', (ctx, shape) ->
+	ctx.fillStyle = shape.fillColor
+	ctx.fillRect(shape.x, shape.y, shape.width, shape.height)
+	ctx.lineWidth = shape.strokeWidth
+	ctx.strokeStyle = shape.strokeColor
+	ctx.strokeRect(shape.x, shape.y, shape.width, shape.height)
+###
+
+
+defineCanvasRenderer 'Ellipse', (ctx, shape) ->
+  ctx.save()
+  halfWidth = Math.floor(shape.width / 2)
+  halfHeight = Math.floor(shape.height / 2)
+  centerX = shape.x + halfWidth
+  centerY = shape.y + halfHeight
+
+  ctx.translate(centerX, centerY)
+  ctx.scale(1, Math.abs(shape.height / shape.width))
+  ctx.beginPath()
+  ctx.arc(0, 0, Math.abs(halfWidth), 0, Math.PI * 2)
+  ctx.closePath()
+  ctx.restore()
+
+  ctx.fillStyle = shape.fillColor
+  ctx.fill()
+  ctx.lineWidth = shape.strokeWidth
+  ctx.strokeStyle = shape.strokeColor
+  ctx.stroke()
+
+
+defineCanvasRenderer 'SelectionBox', do ->
+  _drawHandle = (ctx, shape, {x, y}, handleSize) ->
+    ctx.fillStyle = '#fff'
+    ctx.fillRect(x, y, handleSize, handleSize)
+    ctx.strokeStyle = '#000'
+    ctx.strokeRect(x, y, handleSize, handleSize)
+
+  (ctx, shape) ->
+    if shape.backgroundColor
+      ctx.fillStyle = shape.backgroundColor
+      ctx.fillRect(
+        shape._br.x - shape.margin,
+        shape._br.y - shape.margin,
+        shape._br.width + shape.margin * 2,
+        shape._br.height + shape.margin * 2)
+    ctx.lineWidth = 1
+    ctx.strokeStyle = '#000'
+    ctx.setLineDash([2, 4])
+    ctx.strokeRect(
+      shape._br.x - shape.margin, shape._br.y - shape.margin,
+      shape._br.width + shape.margin * 2, shape._br.height + shape.margin * 2)
+
+    ctx.setLineDash([])
+    _drawHandle(ctx, shape.getTopLeftHandleRect(), shape.handleSize)
+    _drawHandle(ctx, shape.getTopRightHandleRect(), shape.handleSize)
+    _drawHandle(ctx, shape.getBottomLeftHandleRect(), shape.handleSize)
+    _drawHandle(ctx, shape.getBottomRightHandleRect(), shape.handleSize)
+
+
+defineCanvasRenderer 'Image', (ctx, shape, retryCallback) ->
+  if shape.image.width
+    ctx.drawImage(shape.image, shape.x, shape.y)
+  else if retryCallback
+    shape.image.onload = retryCallback
+
+
+defineCanvasRenderer 'Line', (ctx, shape) ->
+  if shape.x1 == shape.x2 and shape.y1 == shape.y2
+    # browser behavior is not consistent for this case.
+    return
+
+  ctx.lineWidth = shape.strokeWidth
+  ctx.strokeStyle = shape.color
+  ctx.lineCap = shape.capStyle
+  ctx.setLineDash(shape.dash) if shape.dash
+  ctx.beginPath()
+  ctx.moveTo(shape.x1, shape.y1)
+  ctx.lineTo(shape.x2, shape.y2)
+  ctx.stroke()
+  ctx.setLineDash([]) if shape.dash
+
+  arrowWidth = Math.max(shape.strokeWidth * 2.2, 5)
+  if shape.endCapShapes[0]
+    lineEndCapShapes[shape.endCapShapes[0]].drawToCanvas(
+      ctx,
+      shape.x1, shape.y1,
+      Math.atan2(shape.y1 - shape.y2, shape.x1 - shape.x2),
+      arrowWidth, shape.color)
+  if shape.endCapShapes[1]
+    lineEndCapShapes[shape.endCapShapes[1]].drawToCanvas(
+      ctx,
+      shape.x2, shape.y2,
+      Math.atan2(shape.y2 - shape.y1, shape.x2 - shape.x1),
+      arrowWidth, shape.color)
+
+
+_drawRawLinePath = (ctx, points) ->
+  return unless points.length
+
+  ctx.lineCap = 'round'
+
+  ctx.strokeStyle = points[0].color
+  ctx.lineWidth = points[0].size
+
+  ctx.beginPath()
+  ctx.moveTo(points[0].x, points[0].y)
+
+  for point in points.slice(1)
+    ctx.lineTo(point.x, point.y)
+
+  ctx.stroke()
+
+
+drawLinePath = (ctx, shape) ->
+  _drawRawLinePath(ctx, shape.smoothedPoints)
+drawLinePathLatest = (ctx, bufferCtx, shape) ->
+  _drawRawLinePath(
+    ctx, if shape.tail then shape.tail else shape.smoothedPoints)
+
+  if shape.tail
+    segmentStart =
+      shape.smoothedPoints.length - shape.segmentSize * shape.tailSize
+    drawStart =
+      if segmentStart < shape.segmentSize * 2 then 0 else segmentStart
+    drawEnd = segmentStart + shape.segmentSize + 1
+    _drawRawLinePath(bufferCtx, shape.smoothedPoints.slice(drawStart, drawEnd))
+
+
+defineCanvasRenderer 'LinePath', drawLinePath, drawLinePathLatest
+
+
+# same as the line path funcs, but erase instead of draw
+drawErasedLinePath = (ctx, shape) ->
+  ctx.save()
+  ctx.globalCompositeOperation = "destination-out"
+  drawLinePath(ctx, shape)
+  ctx.restore()
+drawErasedLinePathLatest = (ctx, bufferCtx, shape) ->
+  ctx.save()
+  ctx.globalCompositeOperation = "destination-out"
+  bufferCtx.save()
+  bufferCtx.globalCompositeOperation = "destination-out"
+
+  drawLinePathLatest(ctx, bufferCtx, shape)
+
+  ctx.restore()
+  bufferCtx.restore()
+
+
+defineCanvasRenderer(
+  'ErasedLinePath', drawErasedLinePath, drawErasedLinePathLatest)
+
+
+defineCanvasRenderer 'Text', (ctx, shape) ->
+    shape._makeRenderer(ctx) unless shape.renderer
+    ctx.fillStyle = shape.color
+    shape.renderer.draw(ctx, shape.x, shape.y)
+
+
+module.exports = {
+  defineCanvasRenderer, renderShapeToCanvas, renderShapeToContext
+}

--- a/src/core/canvasRenderer.coffee
+++ b/src/core/canvasRenderer.coffee
@@ -22,23 +22,21 @@ renderShapeToContext = (ctx, shape, opts={}) ->
     else
       renderers[shape.className].drawFunc(ctx, shape, opts.retryCallback)
   else if opts.ignoreUnsupportedShapes
-    console.warn "Can't render shape of type #{shape.className}"
+    console.warn "Can't render shape of type #{shape.className} to canvas"
   else
-    throw "Can't render shape of type #{shape.className}"
+    throw "Can't render shape of type #{shape.className} to canvas"
 
 
 renderShapeToCanvas = (canvas, shape, opts) ->
   renderShapeToContext(canvas.getContext('2d'), shape, opts)
 
 
-###
 defineCanvasRenderer 'Rectangle', (ctx, shape) ->
 	ctx.fillStyle = shape.fillColor
 	ctx.fillRect(shape.x, shape.y, shape.width, shape.height)
 	ctx.lineWidth = shape.strokeWidth
 	ctx.strokeStyle = shape.strokeColor
 	ctx.strokeRect(shape.x, shape.y, shape.width, shape.height)
-###
 
 
 defineCanvasRenderer 'Ellipse', (ctx, shape) ->

--- a/src/core/canvasRenderer.coffee
+++ b/src/core/canvasRenderer.coffee
@@ -10,7 +10,7 @@ defineCanvasRenderer = (shapeName, drawFunc, drawLatestFunc) ->
 
 noop = ->
 renderShapeToContext = (ctx, shape, opts={}) ->
-  opts.ignoreUnsupportedShapes ?= false
+  opts.shouldIgnoreUnsupportedShapes ?= false
   opts.retryCallback ?= noop
   opts.shouldOnlyDrawLatest = false
   opts.bufferCtx ?= null
@@ -21,7 +21,7 @@ renderShapeToContext = (ctx, shape, opts={}) ->
         ctx, bufferCtx, shape, opts.retryCallback)
     else
       renderers[shape.className].drawFunc(ctx, shape, opts.retryCallback)
-  else if opts.ignoreUnsupportedShapes
+  else if opts.shouldIgnoreUnsupportedShapes
     console.warn "Can't render shape of type #{shape.className} to canvas"
   else
     throw "Can't render shape of type #{shape.className} to canvas"

--- a/src/core/svgRenderer.coffee
+++ b/src/core/svgRenderer.coffee
@@ -1,0 +1,118 @@
+lineEndCapShapes = require './lineEndCapShapes.coffee'
+renderers = {}
+
+
+# shapeToSVG(shape) -> string
+defineSVGRenderer = (shapeName, shapeToSVGFunc) ->
+	renderers[shapeName] = shapeToSVGFunc
+
+
+renderShapeToSVG = (shape, opts={}) ->
+  opts.ignoreUnsupportedShapes ?= false
+
+  if renderers[shape.className]
+    return renderers[shape.className](shape)
+  else if opts.ignoreUnsupportedShapes
+    console.warn "Can't render shape of type #{shape.className} to SVG"
+    return ""
+  else
+    throw "Can't render shape of type #{shape.className} to SVG"
+
+
+defineSVGRenderer 'Rectangle', (shape) ->
+  "
+    <rect x='#{shape.x}' y='#{shape.y}'
+      width='#{shape.width}' height='#{shape.height}'
+      stroke='#{shape.strokeColor}' fill='#{shape.fillColor}'
+      stroke-width='#{shape.strokeWidth}' />
+  "
+
+
+defineSVGRenderer 'Ellipse', (shape) ->
+  halfWidth = Math.floor(shape.width / 2)
+  halfHeight = Math.floor(shape.height / 2)
+  centerX = shape.x + halfWidth
+  centerY = shape.y + halfHeight
+  "
+    <ellipse cx='#{centerX}' cy='#{centerY}' rx='#{halfWidth}'
+      ry='#{halfHeight}'
+      stroke='#{shape.strokeColor}' fill='#{shape.fillColor}'
+      stroke-width='#{shape.strokeWidth}' />
+  "
+
+
+defineSVGRenderer 'Image', (shape) ->
+  # This will only work when embedded in a web page.
+  "
+    <image x='#{shape.x}' y='#{shape.y}'
+      width='#{shape.image.naturalWidth}' height='#{shape.image.naturalHeight}'
+      xlink:href='#{shape.image.src}' />
+  "
+
+
+defineSVGRenderer 'Line', (shape) ->
+  dashString =
+    if shape.dash then "stroke-dasharray='#{shape.dash.join(', ')}'" else ''
+  capString = ''
+  arrowWidth = Math.max(shape.strokeWidth * 2.2, 5)
+  if shape.endCapShapes[0]
+    capString += lineEndCapShapes[shape.endCapShapes[0]].svg(
+      shape.x1, shape.y1, Math.atan2(shape.y1 - shape.y2, shape.x1 - shape.x2),
+      arrowWidth, shape.color)
+  if shape.endCapShapes[1]
+    capString += lineEndCapShapes[shape.endCapShapes[1]].svg(
+      shape.x2, shape.y2, Math.atan2(shape.y2 - shape.y1, shape.x2 - shape.x1),
+      arrowWidth, shape.color)
+  "
+    <g>
+      <line x1='#{shape.x1}' y1='#{shape.y1}' x2='#{shape.x2}' y2='#{shape.y2}'
+        #{dashString}
+        stroke-linecap='#{shape.capStyle}'
+        stroke='#{shape.color}'stroke-width='#{shape.strokeWidth}' />
+      #{capString}
+    <g>
+  "
+
+
+defineSVGRenderer 'LinePath', (shape) ->
+  "
+    <polyline
+      fill='none'
+      points='#{shape.smoothedPoints.map((p) -> "#{p.x},#{p.y}").join(' ')}'
+      stroke='#{shape.points[0].color}'
+      stroke-width='#{shape.points[0].size}' />
+  "
+
+
+# silently skip erasers
+defineSVGRenderer 'ErasedLinePath', (shape) -> ""
+
+
+defineSVGRenderer 'Text', (shape) ->
+  # fallback: don't worry about auto-wrapping
+  widthString =
+    if shape.forcedWidth then "width='#{shape.forcedWidth}px'" else ""
+  heightString =
+    if shape.forcedHeight then "height='#{shape.forcedHeight}px'" else ""
+  textSplitOnLines = shape.text.split(/\r\n|\r|\n/g)
+
+  if shape.renderer
+    textSplitOnLines = shape.renderer.lines
+
+  "
+  <text x='#{shape.x}' y='#{shape.y}'
+        #{widthString} #{heightString}
+        fill='#{shape.color}'
+        style='font: #{shape.font};'>
+    #{textSplitOnLines.map((line, i) =>
+      dy = if i == 0 then 0 else '1.2em'
+      return "
+        <tspan x='#{shape.x}' dy='#{dy}' alignment-baseline='text-before-edge'>
+          #{line}
+        </tspan>"
+    ).join('')}
+  </text>
+  "
+
+
+module.exports = {defineSVGRenderer, renderShapeToSVG}

--- a/src/core/svgRenderer.coffee
+++ b/src/core/svgRenderer.coffee
@@ -8,11 +8,11 @@ defineSVGRenderer = (shapeName, shapeToSVGFunc) ->
 
 
 renderShapeToSVG = (shape, opts={}) ->
-  opts.ignoreUnsupportedShapes ?= false
+  opts.shouldIgnoreUnsupportedShapes ?= false
 
   if renderers[shape.className]
     return renderers[shape.className](shape)
-  else if opts.ignoreUnsupportedShapes
+  else if opts.shouldIgnoreUnsupportedShapes
     console.warn "Can't render shape of type #{shape.className} to SVG"
     return ""
   else

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -1,4 +1,5 @@
 slice = Array.prototype.slice
+{renderShapeToContext} = require './canvasRenderer'
 
 util =
   last: (array, n = null) ->
@@ -44,7 +45,7 @@ util =
     ctx.translate(-bounds.x * scale, -bounds.y * scale)
     ctx.scale(scale, scale)
     for shape in shapes
-      shape.draw(ctx)
+      renderShapeToContext(ctx, shape)
     canvas
 
   # [{x, y, width, height}]

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -4,6 +4,7 @@ require './ie_setLineDash'
 LiterallyCanvas = require './core/LiterallyCanvas'
 initReact = require './reactGUI/init'
 
+canvasRenderer = require './core/canvasRenderer'
 shapes = require './core/shapes'
 util = require './core/util'
 
@@ -123,6 +124,10 @@ module.exports = {
   createShape: shapes.createShape,
   JSONToShape: shapes.JSONToShape,
   shapeToJSON: shapes.shapeToJSON,
+
+  defineCanvasRenderer:  canvasRenderer.defineCanvasRenderer,
+  renderShapeToContext: canvasRenderer.renderShapeToContext,
+  renderShapeToCanvas: canvasRenderer.renderShapeToCanvas,
 
   localize: localize
 }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -5,6 +5,7 @@ LiterallyCanvas = require './core/LiterallyCanvas'
 initReact = require './reactGUI/init'
 
 canvasRenderer = require './core/canvasRenderer'
+svgRenderer = require './core/svgRenderer'
 shapes = require './core/shapes'
 util = require './core/util'
 
@@ -128,6 +129,9 @@ module.exports = {
   defineCanvasRenderer:  canvasRenderer.defineCanvasRenderer,
   renderShapeToContext: canvasRenderer.renderShapeToContext,
   renderShapeToCanvas: canvasRenderer.renderShapeToCanvas,
+
+  defineSVGRenderer: svgRenderer.defineSVGRenderer,
+  renderShapeToSVG: svgRenderer.renderShapeToSVG,
 
   localize: localize
 }


### PR DESCRIPTION
Implementation and use of `Shape.draw()`, `Shape.drawLatest()`, and `Shape.toSVG()` are now deprecated.

Instead, register drawing functions like you register shapes:

```javascript
LC.defineCanvasRenderer(
  shapeName,
  function(ctx, shape, retryCallback) {},
  function(ctx, bufferCtx, shape, retryCallback)
)

LC.renderShapeToContext(
  shape, ctx, {bufferCtx?, retryCallback?, shouldOnlyDrawLatest: false, shouldIgnoreUnsupportedShapes: false})

LC.defineSVGRenderer(shapeName, function(shape) { return "<something />" })
LC.renderShapeToSVG(shape) # -> "<something />"
```

## Why?

`shapes.coffee` was a mishmash of serialization, canvas rendering, SVG rendering, and class construction. Now it's just serialization and class construction, and it's much clearer how one might add additional renderers.
