### PR TITLE
Allow SVG export without a LC instance; static shape test page; sharper rendering

### DIFF
--- a/demo/static-tests.html
+++ b/demo/static-tests.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Literally Canvas static tests</title>
+	    <link href="/lib/css/literallycanvas.css" rel="stylesheet">
+      <style>
+        table {
+          width: 303px;
+          border-collapse: collapse;
+        }
+        td, th {
+          text-align: left;
+          border-bottom: 1px solid black;
+          margin: 0;
+        }
+        td {
+          padding: 2px;
+        }
+        td:first-child {
+          border-left: 1px solid black;
+        }
+        td:nth-child(1), td:nth-child(2), td:nth-child(3) {
+          padding: 0;
+          width: 100px;
+          border-right: 1px solid black;
+        }
+        td > * {
+          display: block;
+        }
+      </style>
+	</head>
+  <body>
+
+    <div style="float: left;">
+      <h1>Pre-image load</h1>
+      <table id="static-test-results">
+        <thead>
+          <tr>
+            <th>Original shape</th>
+            <th>After JSON round trip</th>
+            <th>SVG</th>
+          </tr>
+        </thead>
+        <tbody id="static-test-results-body">
+        </tbody>
+      </table>
+    </div>
+
+    <div style="float: left; margin-left: 20px;">
+      <h1>Post-image load</h1>
+      <table id="static-test-results-2">
+        <thead>
+          <tr>
+            <th>Original shape</th>
+            <th>After JSON round trip</th>
+            <th>SVG</th>
+          </tr>
+        </thead>
+        <tbody id="static-test-results-body-2">
+        </tbody>
+      </table>
+    </div>
+
+    <script src="/demo/react-0.10.0.js"></script>
+    <script src="/lib/js/literallycanvas.js"></script>
+    <script>
+      var img = new Image();
+      img.src = '/demo/bear.png';
+
+      function renderTestResults(tbodyId, shapes) {
+        var tbody = document.getElementById(tbodyId);
+        var makeCanvas = function() {
+          var canvas = document.createElement('canvas');
+          canvas.width = 100;
+          canvas.height = 100;
+          canvas.style.backgroundColor = 'transnparent';
+          canvas.style.width = '100px';
+          canvas.style.height = '100px';
+          return canvas;
+        }
+
+        shapes.map(function(shape) {
+          var canvas1 = makeCanvas();
+          var canvas2 = makeCanvas();
+          var render1 = function() {
+            LC.renderShapeToCanvas(canvas1, shape, {retryCallback: render1});
+          }
+          render1();
+
+          var shape2 = LC.JSONToShape(LC.shapeToJSON(shape));
+          var render2 = function() {
+            LC.renderShapeToCanvas(canvas2, shape2, {retryCallback: render2});
+          }
+          render2();
+
+          var svgString = LC.renderShapesToSVG(
+            [shape], {x: 0, y: 0, width: 100, height: 100}, 'transparent');
+
+          var td1 = document.createElement('td');
+          var td2 = document.createElement('td');
+          var td3 = document.createElement('td');
+          td1.appendChild(canvas1);
+          td2.appendChild(canvas2);
+          td3.innerHTML = svgString;
+          var tr = document.createElement('tr');
+          tr.appendChild(td1);
+          tr.appendChild(td2);
+          tr.appendChild(td3);
+          tbody.appendChild(tr);
+        });
+      }
+
+      var shapes = [
+        LC.createShape('Image', {image: img, x: 0, y: 0}),
+        LC.createShape('Rectangle', {
+          x: 10, y: 10, width: 80, height: 80,
+          strokeColor: '#000', fillColor: 'red'
+        }),
+        LC.createShape('Ellipse', {
+          x: 0, y: 0, width: 100, height: 100,
+          strokeColor: '#000', fillColor: 'red'
+        })
+      ];
+      renderTestResults('static-test-results-body', shapes);
+
+      var oldImageOnload = img.onload;
+      img.onload = function() {
+        oldImageOnload();
+        renderTestResults('static-test-results-body-2', shapes);
+      }
+    </script>
+    <script src="//localhost:35728/livereload.js"></script>
+  </body>
+</html>

--- a/demo/static-tests.html
+++ b/demo/static-tests.html
@@ -122,6 +122,10 @@
           x: 10, y: 10, width: 80, height: 80,
           strokeColor: '#000', fillColor: 'red'
         }),
+        LC.createShape('Rectangle', {
+          x: 10, y: 10, width: 80, height: 80,
+          strokeColor: '#000', fillColor: 'red', strokeWidth: 2
+        }),
         LC.createShape('Ellipse', {
           x: 10, y: 10, width: 80, height: 80,
           strokeColor: '#000', fillColor: 'red'
@@ -133,6 +137,10 @@
         LC.createShape('Line', {
           x1: 10, y1: 10, x2: 10, y2: 90,
           strokeColor: '#000', strokeWidth: 1
+        }),
+        LC.createShape('Line', {
+          x1: 10, y1: 10, x2: 10, y2: 90,
+          strokeColor: '#000', strokeWidth: 2
         }),
         LC.createShape('Line', {
           x1: 10, y1: 10, x2: 90, y2: 90,
@@ -150,6 +158,14 @@
             LC.createShape('Point', {x: 10, y: 90, size: 1, color: '#000'}),
             LC.createShape('Point', {x: 90, y: 90, size: 1, color: '#000'}),
             LC.createShape('Point', {x: 90, y: 10, size: 1, color: '#000'})
+          ]
+        }),
+        LC.createShape('LinePath', {
+          points: [
+            LC.createShape('Point', {x: 10, y: 10, size: 2, color: '#000'}),
+            LC.createShape('Point', {x: 10, y: 90, size: 2, color: '#000'}),
+            LC.createShape('Point', {x: 90, y: 90, size: 2, color: '#000'}),
+            LC.createShape('Point', {x: 90, y: 10, size: 2, color: '#000'})
           ]
         }),
         LC.createShape('ErasedLinePath', {

--- a/demo/static-tests.html
+++ b/demo/static-tests.html
@@ -69,19 +69,25 @@
 
       function renderTestResults(tbodyId, shapes) {
         var tbody = document.getElementById(tbodyId);
-        var makeCanvas = function() {
+        var makeCanvas = function(shapeClassName) {
           var canvas = document.createElement('canvas');
           canvas.width = 100;
           canvas.height = 100;
           canvas.style.backgroundColor = 'transnparent';
           canvas.style.width = '100px';
           canvas.style.height = '100px';
+
+          if (shapeClassName == 'ErasedLinePath') {
+            var ctx = canvas.getContext('2d');
+            ctx.fillStyle = '#00f'
+            ctx.fillRect(0, 0, 100, 100);
+          }
           return canvas;
         }
 
         shapes.map(function(shape) {
-          var canvas1 = makeCanvas();
-          var canvas2 = makeCanvas();
+          var canvas1 = makeCanvas(shape.className);
+          var canvas2 = makeCanvas(shape.className);
           var render1 = function() {
             LC.renderShapeToCanvas(canvas1, shape, {retryCallback: render1});
           }
@@ -117,8 +123,50 @@
           strokeColor: '#000', fillColor: 'red'
         }),
         LC.createShape('Ellipse', {
-          x: 0, y: 0, width: 100, height: 100,
+          x: 10, y: 10, width: 80, height: 80,
           strokeColor: '#000', fillColor: 'red'
+        }),
+        LC.createShape('Line', {
+          x1: 10, y1: 10, x2: 90, y2: 90,
+          strokeColor: '#000', strokeWidth: 1
+        }),
+        LC.createShape('Line', {
+          x1: 10, y1: 10, x2: 90, y2: 90,
+          strokeColor: '#000', strokeWidth: 1,
+          dash: [2, 4], endCapShapes: ['arrow', 'arrow']
+        }),
+        LC.createShape('Line', {
+          x1: 10, y1: 10, x2: 90, y2: 90,
+          strokeColor: '#000', strokeWidth: 5,
+          dash: [10, 20], endCapShapes: ['arrow', 'arrow']
+        }),
+        LC.createShape('LinePath', {
+          points: [
+            LC.createShape('Point', {x: 10, y: 10, size: 1, color: '#000'}),
+            LC.createShape('Point', {x: 10, y: 90, size: 1, color: '#000'}),
+            LC.createShape('Point', {x: 90, y: 90, size: 1, color: '#000'}),
+            LC.createShape('Point', {x: 90, y: 10, size: 1, color: '#000'})
+          ]
+        }),
+        LC.createShape('ErasedLinePath', {
+          points: [
+            LC.createShape('Point', {x: 10, y: 10, size: 1, color: '#000'}),
+            LC.createShape('Point', {x: 10, y: 90, size: 1, color: '#000'}),
+            LC.createShape('Point', {x: 90, y: 90, size: 1, color: '#000'}),
+            LC.createShape('Point', {x: 90, y: 10, size: 1, color: '#000'})
+          ]
+        }),
+        LC.createShape('Text', {
+          x: 0, y: 0, v: 1,
+          text: "one\ntwo three four five",
+          color: '#000', font: '18px bold Helvetica',
+          forcedWidth: 100, forcedHeight: 100
+        }),
+        LC.createShape('Text', {
+          x: 0, y: 24, v: 0,
+          text: "one\ntwo three four five",
+          color: '#000', font: '18px bold Helvetica',
+          forcedWidth: 100, forcedHeight: 100
         })
       ];
       renderTestResults('static-test-results-body', shapes);

--- a/demo/static-tests.html
+++ b/demo/static-tests.html
@@ -131,6 +131,10 @@
           strokeColor: '#000', strokeWidth: 1
         }),
         LC.createShape('Line', {
+          x1: 10, y1: 10, x2: 10, y2: 90,
+          strokeColor: '#000', strokeWidth: 1
+        }),
+        LC.createShape('Line', {
           x1: 10, y1: 10, x2: 90, y2: 90,
           strokeColor: '#000', strokeWidth: 1,
           dash: [2, 4], endCapShapes: ['arrow', 'arrow']

--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -428,23 +428,11 @@ module.exports = class LiterallyCanvas
     # {x, y, width, height}
     opts.rect ?= @getContentBounds()
 
-    {x, y, width, height} = opts.rect
     if not (opts.rect.width and opts.rect.height)
       return
 
-    "
-      <svg
-          xmlns='http://www.w3.org/2000/svg'
-          width='#{width}' height='#{height}'
-          viewBox='0 0 #{width} #{height}'>
-        <rect width='#{width}' height='#{height}' x='0' y='0'
-          fill='#{@colors.background}' />
-        <g transform='translate(#{-x}, #{-y})'>
-          #{@backgroundShapes.map(renderShapeToSVG).join('')}
-          #{@shapes.map(renderShapeToSVG).join('')}
-        </g>
-      </svg>
-    ".replace(/(\r\n|\n|\r)/gm,"")
+    util.renderShapesToSVG(
+      @backgroundShapes.concat(@shapes), opts.rect, @colors.background)
 
   loadSnapshot: (snapshot) ->
     return unless snapshot

--- a/src/core/canvasRenderer.coffee
+++ b/src/core/canvasRenderer.coffee
@@ -33,10 +33,10 @@ renderShapeToCanvas = (canvas, shape, opts) ->
 
 defineCanvasRenderer 'Rectangle', (ctx, shape) ->
 	ctx.fillStyle = shape.fillColor
-	ctx.fillRect(shape.x, shape.y, shape.width, shape.height)
+	ctx.fillRect(shape.x + 0.5, shape.y + 0.5, shape.width, shape.height)
 	ctx.lineWidth = shape.strokeWidth
 	ctx.strokeStyle = shape.strokeColor
-	ctx.strokeRect(shape.x, shape.y, shape.width, shape.height)
+	ctx.strokeRect(shape.x + 0.5, shape.y + 0.5, shape.width, shape.height)
 
 
 defineCanvasRenderer 'Ellipse', (ctx, shape) ->
@@ -101,29 +101,28 @@ defineCanvasRenderer 'Line', (ctx, shape) ->
     # browser behavior is not consistent for this case.
     return
 
+  x1 = shape.x1 + 0.5
+  x2 = shape.x2 + 0.5
+  y1 = shape.y1 + 0.5
+  y2 = shape.y2 + 0.5
+
   ctx.lineWidth = shape.strokeWidth
   ctx.strokeStyle = shape.color
   ctx.lineCap = shape.capStyle
   ctx.setLineDash(shape.dash) if shape.dash
   ctx.beginPath()
-  ctx.moveTo(shape.x1, shape.y1)
-  ctx.lineTo(shape.x2, shape.y2)
+  ctx.moveTo(x1, y1)
+  ctx.lineTo(x2, y2)
   ctx.stroke()
   ctx.setLineDash([]) if shape.dash
 
   arrowWidth = Math.max(shape.strokeWidth * 2.2, 5)
   if shape.endCapShapes[0]
     lineEndCapShapes[shape.endCapShapes[0]].drawToCanvas(
-      ctx,
-      shape.x1, shape.y1,
-      Math.atan2(shape.y1 - shape.y2, shape.x1 - shape.x2),
-      arrowWidth, shape.color)
+      ctx, x1, y1, Math.atan2(y1 - y2, x1 - x2), arrowWidth, shape.color)
   if shape.endCapShapes[1]
     lineEndCapShapes[shape.endCapShapes[1]].drawToCanvas(
-      ctx,
-      shape.x2, shape.y2,
-      Math.atan2(shape.y2 - shape.y1, shape.x2 - shape.x1),
-      arrowWidth, shape.color)
+      ctx, x2, y2, Math.atan2(y2 - y1, x2 - x1), arrowWidth, shape.color)
 
 
 _drawRawLinePath = (ctx, points) ->
@@ -135,10 +134,10 @@ _drawRawLinePath = (ctx, points) ->
   ctx.lineWidth = points[0].size
 
   ctx.beginPath()
-  ctx.moveTo(points[0].x, points[0].y)
+  ctx.moveTo(points[0].x+0.5, points[0].y+0.5)
 
   for point in points.slice(1)
-    ctx.lineTo(point.x, point.y)
+    ctx.lineTo(point.x+0.5, point.y+0.5)
 
   ctx.stroke()
 

--- a/src/core/canvasRenderer.coffee
+++ b/src/core/canvasRenderer.coffee
@@ -32,11 +32,17 @@ renderShapeToCanvas = (canvas, shape, opts) ->
 
 
 defineCanvasRenderer 'Rectangle', (ctx, shape) ->
-	ctx.fillStyle = shape.fillColor
-	ctx.fillRect(shape.x + 0.5, shape.y + 0.5, shape.width, shape.height)
-	ctx.lineWidth = shape.strokeWidth
-	ctx.strokeStyle = shape.strokeColor
-	ctx.strokeRect(shape.x + 0.5, shape.y + 0.5, shape.width, shape.height)
+  x = shape.x
+  y = shape.y
+  if shape.strokeWidth % 2 != 0
+    x += 0.5
+    y += 0.5
+
+  ctx.fillStyle = shape.fillColor
+  ctx.fillRect(x, y, shape.width, shape.height)
+  ctx.lineWidth = shape.strokeWidth
+  ctx.strokeStyle = shape.strokeColor
+  ctx.strokeRect(x, y, shape.width, shape.height)
 
 
 defineCanvasRenderer 'Ellipse', (ctx, shape) ->
@@ -101,10 +107,15 @@ defineCanvasRenderer 'Line', (ctx, shape) ->
     # browser behavior is not consistent for this case.
     return
 
-  x1 = shape.x1 + 0.5
-  x2 = shape.x2 + 0.5
-  y1 = shape.y1 + 0.5
-  y2 = shape.y2 + 0.5
+  x1 = shape.x1
+  x2 = shape.x2
+  y1 = shape.y1
+  y2 = shape.y2
+  if shape.strokeWidth % 2 != 0
+    x1 += 0.5
+    x2 += 0.5
+    y1 += 0.5
+    y2 += 0.5
 
   ctx.lineWidth = shape.strokeWidth
   ctx.strokeStyle = shape.color
@@ -134,10 +145,17 @@ _drawRawLinePath = (ctx, points) ->
   ctx.lineWidth = points[0].size
 
   ctx.beginPath()
-  ctx.moveTo(points[0].x+0.5, points[0].y+0.5)
+
+  if points[0].size % 2 == 0
+    ctx.moveTo(points[0].x, points[0].y)
+  else
+    ctx.moveTo(points[0].x+0.5, points[0].y+0.5)
 
   for point in points.slice(1)
-    ctx.lineTo(point.x+0.5, point.y+0.5)
+    if points[0].size % 2 == 0
+      ctx.lineTo(point.x, point.y)
+    else
+      ctx.lineTo(point.x+0.5, point.y+0.5)
 
   ctx.stroke()
 

--- a/src/core/svgRenderer.coffee
+++ b/src/core/svgRenderer.coffee
@@ -20,8 +20,14 @@ renderShapeToSVG = (shape, opts={}) ->
 
 
 defineSVGRenderer 'Rectangle', (shape) ->
+  x = shape.x
+  y = shape.y
+  if shape.strokeWidth % 2 != 0
+    x += 0.5
+    y += 0.5
+
   "
-    <rect x='#{shape.x+0.5}' y='#{shape.y+0.5}'
+    <rect x='#{x}' y='#{y}'
       width='#{shape.width}' height='#{shape.height}'
       stroke='#{shape.strokeColor}' fill='#{shape.fillColor}'
       stroke-width='#{shape.strokeWidth}' />
@@ -56,10 +62,15 @@ defineSVGRenderer 'Line', (shape) ->
   capString = ''
   arrowWidth = Math.max(shape.strokeWidth * 2.2, 5)
 
-  x1 = shape.x1 + 0.5
-  x2 = shape.x2 + 0.5
-  y1 = shape.y1 + 0.5
-  y2 = shape.y2 + 0.5
+  x1 = shape.x1
+  x2 = shape.x2
+  y1 = shape.y1
+  y2 = shape.y2
+  if shape.strokeWidth % 2 != 0
+    x1 += 0.5
+    x2 += 0.5
+    y1 += 0.5
+    y2 += 0.5
 
   if shape.endCapShapes[0]
     capString += lineEndCapShapes[shape.endCapShapes[0]].svg(
@@ -83,7 +94,8 @@ defineSVGRenderer 'LinePath', (shape) ->
     <polyline
       fill='none'
       points='#{shape.smoothedPoints.map((p) ->
-        "#{p.x+0.5},#{p.y+0.5}").join(' ')
+        offset = if p.strokeWidth % 2 == 0 then 0.0 else 0.5
+        "#{p.x+offset},#{p.y+offset}").join(' ')
       }'
       stroke='#{shape.points[0].color}'
       stroke-width='#{shape.points[0].size}' />

--- a/src/core/svgRenderer.coffee
+++ b/src/core/svgRenderer.coffee
@@ -21,7 +21,7 @@ renderShapeToSVG = (shape, opts={}) ->
 
 defineSVGRenderer 'Rectangle', (shape) ->
   "
-    <rect x='#{shape.x}' y='#{shape.y}'
+    <rect x='#{shape.x+0.5}' y='#{shape.y+0.5}'
       width='#{shape.width}' height='#{shape.height}'
       stroke='#{shape.strokeColor}' fill='#{shape.fillColor}'
       stroke-width='#{shape.strokeWidth}' />
@@ -55,17 +55,21 @@ defineSVGRenderer 'Line', (shape) ->
     if shape.dash then "stroke-dasharray='#{shape.dash.join(', ')}'" else ''
   capString = ''
   arrowWidth = Math.max(shape.strokeWidth * 2.2, 5)
+
+  x1 = shape.x1 + 0.5
+  x2 = shape.x2 + 0.5
+  y1 = shape.y1 + 0.5
+  y2 = shape.y2 + 0.5
+
   if shape.endCapShapes[0]
     capString += lineEndCapShapes[shape.endCapShapes[0]].svg(
-      shape.x1, shape.y1, Math.atan2(shape.y1 - shape.y2, shape.x1 - shape.x2),
-      arrowWidth, shape.color)
+      x1, y1, Math.atan2(y1 - y2, x1 - x2), arrowWidth, shape.color)
   if shape.endCapShapes[1]
     capString += lineEndCapShapes[shape.endCapShapes[1]].svg(
-      shape.x2, shape.y2, Math.atan2(shape.y2 - shape.y1, shape.x2 - shape.x1),
-      arrowWidth, shape.color)
+      x2, y2, Math.atan2(y2 - y1, x2 - x1), arrowWidth, shape.color)
   "
     <g>
-      <line x1='#{shape.x1}' y1='#{shape.y1}' x2='#{shape.x2}' y2='#{shape.y2}'
+      <line x1='#{x1}' y1='#{y1}' x2='#{x2}' y2='#{y2}'
         #{dashString}
         stroke-linecap='#{shape.capStyle}'
         stroke='#{shape.color}'stroke-width='#{shape.strokeWidth}' />
@@ -78,7 +82,9 @@ defineSVGRenderer 'LinePath', (shape) ->
   "
     <polyline
       fill='none'
-      points='#{shape.smoothedPoints.map((p) -> "#{p.x},#{p.y}").join(' ')}'
+      points='#{shape.smoothedPoints.map((p) ->
+        "#{p.x+0.5},#{p.y+0.5}").join(' ')
+      }'
       stroke='#{shape.points[0].color}'
       stroke-width='#{shape.points[0].size}' />
   "

--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -1,5 +1,6 @@
 slice = Array.prototype.slice
 {renderShapeToContext} = require './canvasRenderer'
+{renderShapeToSVG} = require './svgRenderer'
 
 util =
   last: (array, n = null) ->
@@ -47,6 +48,20 @@ util =
     for shape in shapes
       renderShapeToContext(ctx, shape)
     canvas
+
+  renderShapesToSVG: (shapes, {x, y, width, height}, backgroundColor) ->
+    "
+      <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width='#{width}' height='#{height}'
+          viewBox='0 0 #{width} #{height}'>
+        <rect width='#{width}' height='#{height}' x='0' y='0'
+          fill='#{backgroundColor}' />
+        <g transform='translate(#{-x}, #{-y})'>
+          #{shapes.map(renderShapeToSVG).join('')}
+        </g>
+      </svg>
+    ".replace(/(\r\n|\n|\r)/gm,"")
 
   # [{x, y, width, height}]
   getBoundingRect: (rects, width, height) ->

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -132,6 +132,7 @@ module.exports = {
 
   defineSVGRenderer: svgRenderer.defineSVGRenderer,
   renderShapeToSVG: svgRenderer.renderShapeToSVG,
+  renderShapesToSVG: util.renderShapesToSVG,
 
   localize: localize
 }


### PR DESCRIPTION
* `LC.renderShapesToCanvas(shapes, rect, backgroundColor)`
* `demo/static-test.html` renders all shapes to canvas and SVG. Should make shape changes break less.
* Offset rects, lines, and line paths by 0.5px so they render sharply on the pixel grid.