### PR TITLE
Set stroke width by event instead of directly

### DIFF
--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -60,7 +60,7 @@ module.exports = class LiterallyCanvas
     @scale = 1.0
     # GUI immediately replaces this value, but it's initialized so you can have
     # something really simple
-    @tool = new @opts.tools[0](this)
+    @setTool(new @opts.tools[0](this))
 
     @width = opts.imageSize.width or INFINITE
     @height = opts.imageSize.height or INFINITE
@@ -118,7 +118,7 @@ module.exports = class LiterallyCanvas
     @trigger('imageSizeChange', {@width, @height})
 
   setTool: (tool) ->
-    @tool.willBecomeInactive(this)
+    @tool?.willBecomeInactive(this)
     @tool = tool
     @trigger('toolChange', {tool})
     tool.didBecomeActive(this)

--- a/src/reactGUI/StrokeWidthPicker.coffee
+++ b/src/reactGUI/StrokeWidthPicker.coffee
@@ -25,7 +25,7 @@ module.exports = React.createClass
             {
               className: buttonClassName,
               onClick: =>
-                @props.tool.strokeWidth = strokeWidth
+                @props.lc.trigger 'setStrokeWidth', strokeWidth
                 @setState @getState()
             },
             (svg \

--- a/src/tools/Eraser.coffee
+++ b/src/tools/Eraser.coffee
@@ -7,9 +7,6 @@ module.exports = class Eraser extends Pencil
   name: 'Eraser'
   iconName: 'eraser'
 
-  constructor: () ->
-    @strokeWidth = 10
-
   makePoint: (x, y, lc) ->
     createShape('Point', {x, y, size: @strokeWidth, color: '#000'})
   makeShape: -> createShape('ErasedLinePath')

--- a/src/tools/Line.coffee
+++ b/src/tools/Line.coffee
@@ -7,7 +7,6 @@ module.exports = class Line extends ToolWithStroke
   name: 'Line'
   iconName: 'line'
 
-  constructor: -> @strokeWidth = 5
   optionsStyle: 'line-options-and-stroke-width'
 
   begin: (x, y, lc) ->

--- a/src/tools/Line.coffee
+++ b/src/tools/Line.coffee
@@ -1,8 +1,8 @@
-{Tool} = require './base'
+{ToolWithStroke} = require './base'
 {createShape} = require '../core/shapes'
 
 
-module.exports = class Line extends Tool
+module.exports = class Line extends ToolWithStroke
 
   name: 'Line'
   iconName: 'line'

--- a/src/tools/Polygon.coffee
+++ b/src/tools/Polygon.coffee
@@ -8,9 +8,10 @@ module.exports = class Polygon extends ToolWithStroke
   usesSimpleAPI: false
 
   didBecomeActive: (lc) ->
-    unsubscribeFuncs = []
-    @unsubscribe = =>
-      for func in unsubscribeFuncs
+    super(lc)
+    polygonUnsubscribeFuncs = []
+    @polygonUnsubscribe = =>
+      for func in polygonUnsubscribeFuncs
         func()
 
     @points = null
@@ -52,19 +53,20 @@ module.exports = class Polygon extends ToolWithStroke
     polygonCancel = () =>
       @_cancel(lc)
 
-    unsubscribeFuncs.push lc.on 'drawingChange', => @_cancel(lc)
-    unsubscribeFuncs.push lc.on 'lc-pointerdown', onDown
-    unsubscribeFuncs.push lc.on 'lc-pointerdrag', onMove
-    unsubscribeFuncs.push lc.on 'lc-pointermove', onMove
-    unsubscribeFuncs.push lc.on 'lc-pointerup', onUp
+    polygonUnsubscribeFuncs.push lc.on 'drawingChange', => @_cancel(lc)
+    polygonUnsubscribeFuncs.push lc.on 'lc-pointerdown', onDown
+    polygonUnsubscribeFuncs.push lc.on 'lc-pointerdrag', onMove
+    polygonUnsubscribeFuncs.push lc.on 'lc-pointermove', onMove
+    polygonUnsubscribeFuncs.push lc.on 'lc-pointerup', onUp
 
-    unsubscribeFuncs.push lc.on 'lc-polygon-finishopen', polygonFinishOpen
-    unsubscribeFuncs.push lc.on 'lc-polygon-finishclosed', polygonFinishClosed
-    unsubscribeFuncs.push lc.on 'lc-polygon-cancel', polygonCancel
+    polygonUnsubscribeFuncs.push lc.on 'lc-polygon-finishopen', polygonFinishOpen
+    polygonUnsubscribeFuncs.push lc.on 'lc-polygon-finishclosed', polygonFinishClosed
+    polygonUnsubscribeFuncs.push lc.on 'lc-polygon-cancel', polygonCancel
 
   willBecomeInactive: (lc) ->
+    super(lc)
     @_cancel(lc) if @points or @maybePoint
-    @unsubscribe()
+    @polygonUnsubscribe()
 
   _getArePointsClose: (a, b) ->
     return (Math.abs(a.x - b.x) + Math.abs(a.y - b.y)) < 10

--- a/src/tools/base.coffee
+++ b/src/tools/base.coffee
@@ -31,5 +31,16 @@ tools.ToolWithStroke = class ToolWithStroke extends Tool
   constructor: (lc) -> @strokeWidth = lc.opts.defaultStrokeWidth
   optionsStyle: 'stroke-width'
 
+  didBecomeActive: (lc) ->
+    unsubscribeFuncs = []
+    @unsubscribe = =>
+      for func in unsubscribeFuncs
+        func()
+
+    unsubscribeFuncs.push lc.on 'setStrokeWidth', (strokeWidth) =>
+      @strokeWidth = strokeWidth
+
+  willBecomeInactive: (lc) ->
+    @unsubscribe()
 
 module.exports = tools


### PR DESCRIPTION
No functionality was changed - everything still works exactly as it did before.

(Well, except for the initial strokeWidths on line tool and eraser -- is this acceptable?)

But now, stroke width is changed by triggering 'setStrokeWidth' instead of directly modifying the tool's properties.

This makes it easier for people who are using only the core library to build their own stroke width picker.