### PR TITLE
Decouple polygon tool from UI elements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ v0.4.11:
  * 'scale' parameter for the Image shape
  * Fix text box drag handles (they were invisible)
  * Transparency and saturation sliders in color picker
+ * Build a literallycanvas-core library that does not include the tool UI
+ * Decouple polygon tool UI from tool; trigger 'lc-polygon*' events
 
 v0.4.10:
  * Fix the text tool

--- a/demo/core_demo.html
+++ b/demo/core_demo.html
@@ -98,6 +98,7 @@
         <a href="javascript:void(0);" class='tool' id="tool-dashed">Dashed Line</a>
         <a href="javascript:void(0);" class='tool' id="tool-ellipse">Ellipse</a>
         <a href="javascript:void(0);" class='tool' id="tool-rectangle">Rectangle</a>
+        <a href="javascript:void(0);" class='tool' id="tool-polygon">Polygon</a>
       </div>
 
 <!-- SIZES WON'T WORK UNTIL SIZE EVENT PR IS MERGED! -->
@@ -244,6 +245,10 @@
             name: 'tool-rectangle',
             el: document.getElementById('tool-rectangle'),
             tool: new LC.tools.Rectangle(lc)
+          },{
+            name: 'tool-polygon',
+            el: document.getElementById('tool-polygon'),
+            tool: new LC.tools.Polygon(lc)
           }
         ];
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -17,6 +17,7 @@ initReact = require './reactGUI/init'
 require './optionsStyles/font'
 require './optionsStyles/stroke-width'
 require './optionsStyles/line-options-and-stroke-width'
+require './optionsStyles/polygon-and-stroke-width'
 require './optionsStyles/null'
 React.initializeTouchEvents(true)
 {defineOptionsStyle} = require './optionsStyles/optionsStyles'

--- a/src/optionsStyles/polygon-and-stroke-width.coffee
+++ b/src/optionsStyles/polygon-and-stroke-width.coffee
@@ -18,10 +18,10 @@ defineOptionsStyle 'polygon-and-stroke-width', React.createClass
         func()
 
     showPolygonTools = () =>
-      this.setState({ inProgress: true });
+      @setState({ inProgress: true }) unless @state.inProgress;
 
     hidePolygonTools = () =>
-      this.setState({ inProgress: false });
+      @setState({ inProgress: false });
 
     unsubscribeFuncs.push lc.on 'lc-polygon-started', showPolygonTools
     unsubscribeFuncs.push lc.on 'lc-polygon-stopped', hidePolygonTools
@@ -42,15 +42,15 @@ defineOptionsStyle 'polygon-and-stroke-width', React.createClass
     polygonCancel = () =>
       lc.trigger 'lc-polygon-cancel'
 
-    polygonToolStyle = {float: 'left', margin: 1}
-    polygonToolStyle.display = 'none' unless @state.inProgress
+    polygonToolStyle = {}
+    polygonToolStyle = {display: 'none'} unless @state.inProgress
 
     div {},
-      (div {className: 'square-toolbar-button', onClick: polygonFinishOpen, polygonToolStyle},
+      (div {className: 'square-toolbar-button', onClick: polygonFinishOpen, style: polygonToolStyle},
         img {src: "#{@props.imageURLPrefix}/polygon-open.png"}),
-      (div {className: 'square-toolbar-button', onClick: polygonFinishClosed, polygonToolStyle},
+      (div {className: 'square-toolbar-button', onClick: polygonFinishClosed, style: polygonToolStyle},
         img {src: "#{@props.imageURLPrefix}/polygon-closed.png"}),
-      (div {className: 'square-toolbar-button', onClick: polygonCancel, polygonToolStyle},
+      (div {className: 'square-toolbar-button', onClick: polygonCancel, style: polygonToolStyle},
         img {src: "#{@props.imageURLPrefix}/polygon-cancel.png"}),
       (StrokeWidthPicker {tool: @props.tool, lc: @props.lc})
 

--- a/src/optionsStyles/polygon-and-stroke-width.coffee
+++ b/src/optionsStyles/polygon-and-stroke-width.coffee
@@ -1,0 +1,58 @@
+{defineOptionsStyle} = require './optionsStyles'
+StrokeWidthPicker = React.createFactory require '../reactGUI/StrokeWidthPicker'
+createSetStateOnEventMixin = require '../reactGUI/createSetStateOnEventMixin'
+
+defineOptionsStyle 'polygon-and-stroke-width', React.createClass
+  displayName: 'PolygonAndStrokeWidth'
+  getState: -> {
+    strokeWidth: @props.tool.strokeWidth
+    inProgress: false
+  }
+  getInitialState: -> @getState()
+  mixins: [createSetStateOnEventMixin('toolChange')]
+
+  componentDidMount: ->
+    unsubscribeFuncs = []
+    @unsubscribe = =>
+      for func in unsubscribeFuncs
+        func()
+
+    showPolygonTools = () =>
+      this.setState({ inProgress: true });
+
+    hidePolygonTools = () =>
+      this.setState({ inProgress: false });
+
+    unsubscribeFuncs.push lc.on 'lc-polygon-started', showPolygonTools
+    unsubscribeFuncs.push lc.on 'lc-polygon-stopped', hidePolygonTools
+
+  componentWillUnmount: ->
+    @unsubscribe()
+
+  render: ->
+    lc = @props.lc
+    {div, img} = React.DOM
+
+    polygonFinishOpen = () =>
+      lc.trigger 'lc-polygon-finishopen'
+
+    polygonFinishClosed = () =>
+      lc.trigger 'lc-polygon-finishclosed'
+
+    polygonCancel = () =>
+      lc.trigger 'lc-polygon-cancel'
+
+    polygonToolStyle = {float: 'left', margin: 1}
+    polygonToolStyle.display = 'none' unless @state.inProgress
+
+    div {},
+      (div {className: 'square-toolbar-button', onClick: polygonFinishOpen, polygonToolStyle},
+        img {src: "#{@props.imageURLPrefix}/polygon-open.png"}),
+      (div {className: 'square-toolbar-button', onClick: polygonFinishClosed, polygonToolStyle},
+        img {src: "#{@props.imageURLPrefix}/polygon-closed.png"}),
+      (div {className: 'square-toolbar-button', onClick: polygonCancel, polygonToolStyle},
+        img {src: "#{@props.imageURLPrefix}/polygon-cancel.png"}),
+      (StrokeWidthPicker {tool: @props.tool, lc: @props.lc})
+
+
+module.exports = {}

--- a/src/tools/Polygon.coffee
+++ b/src/tools/Polygon.coffee
@@ -1,7 +1,7 @@
 {ToolWithStroke} = require './base'
 {createShape} = require '../core/shapes'
 
-module.exports = class Pencil extends ToolWithStroke
+module.exports = class Polygon extends ToolWithStroke
 
   name: 'Polygon'
   iconName: 'polygon'

--- a/src/tools/Polygon.coffee
+++ b/src/tools/Polygon.coffee
@@ -18,7 +18,7 @@ module.exports = class Polygon extends ToolWithStroke
 
     onUp = =>
       return @_close(lc) if @_getWillFinish()
-      @_ensureFinishButtonsExist(lc) unless @points
+      lc.trigger 'lc-polygon-started'
 
       if @points
         @points.push(@maybePoint)
@@ -41,11 +41,26 @@ module.exports = class Polygon extends ToolWithStroke
       lc.setShapesInProgress(@_getShapes(lc))
       lc.repaintLayer('main')
 
+    polygonFinishOpen = () =>
+      @maybePoint = {x: Infinity, y: Infinity}
+      @_close(lc)
+
+    polygonFinishClosed = () =>
+      @maybePoint = @points[0]
+      @_close(lc)
+
+    polygonCancel = () =>
+      @_cancel(lc)
+
     unsubscribeFuncs.push lc.on 'drawingChange', => @_cancel(lc)
     unsubscribeFuncs.push lc.on 'lc-pointerdown', onDown
     unsubscribeFuncs.push lc.on 'lc-pointerdrag', onMove
     unsubscribeFuncs.push lc.on 'lc-pointermove', onMove
     unsubscribeFuncs.push lc.on 'lc-pointerup', onUp
+
+    unsubscribeFuncs.push lc.on 'lc-polygon-finishopen', polygonFinishOpen
+    unsubscribeFuncs.push lc.on 'lc-polygon-finishclosed', polygonFinishClosed
+    unsubscribeFuncs.push lc.on 'lc-polygon-cancel', polygonCancel
 
   willBecomeInactive: (lc) ->
     @_cancel(lc) if @points or @maybePoint
@@ -67,14 +82,14 @@ module.exports = class Polygon extends ToolWithStroke
       @_getArePointsClose(@points[@points.length - 1], @maybePoint))
 
   _cancel: (lc) ->
-    @_ensureFinishButtonsDontExist(lc)
+    lc.trigger 'lc-polygon-stopped'
     @maybePoint = null
     @points = null
     lc.setShapesInProgress([])
     lc.repaintLayer('main')
 
   _close: (lc) ->
-    @_ensureFinishButtonsDontExist(lc)
+    lc.trigger 'lc-polygon-stopped'
     lc.setShapesInProgress([])
     lc.saveShape(@_getShape(lc, false)) if @points.length > 2
     @maybePoint = null
@@ -102,54 +117,4 @@ module.exports = class Polygon extends ToolWithStroke
     else
       null
 
-  _ensureFinishButtonsExist: (lc) ->
-    return if @containerEl
-    html = "
-      <div
-        class='square-toolbar-button horz-toolbar'
-        id='polygon-finish-closed'>
-        <img
-          alt='Finish polygon (closed)'
-          title='Finish polygon (closed)'
-          src='#{lc.opts.imageURLPrefix}/polygon-closed.png'>
-      </div>
-      <div
-        class='square-toolbar-button horz-toolbar'
-        id='polygon-finish-open'>
-        <img
-          alt='Finish polygon (open)'
-          title='Finish polygon (open)'
-          src='#{lc.opts.imageURLPrefix}/polygon-open.png'>
-      </div>
-      <div
-        class='square-toolbar-button horz-toolbar'
-        id='polygon-cancel'>
-        <img
-          alt='Cancel polygon'
-          title='Cancel polygon'
-          src='#{lc.opts.imageURLPrefix}/polygon-cancel.png'>
-      </div>
-    "
-    @containerEl = document.createElement('div')
-    @containerEl.className = "polygon-toolbar horz-toolbar"
-    @containerEl.innerHTML = html
-    lc.containerEl.appendChild(@containerEl)
-
-    document.getElementById('polygon-finish-closed')
-      .addEventListener 'click', (e) =>
-        @maybePoint = @points[0]
-        @_close(lc)
-
-    document.getElementById('polygon-finish-open')
-      .addEventListener 'click', (e) =>
-        @maybePoint = {x: Infinity, y: Infinity}
-        @_close(lc)
-
-    document.getElementById('polygon-cancel')
-      .addEventListener 'click', (e) =>
-        @_cancel(lc)
-
-  _ensureFinishButtonsDontExist: (lc) ->
-    return unless @containerEl
-    lc.containerEl.removeChild(@containerEl)
-    @containerEl = null
+  optionsStyle: 'polygon-and-stroke-width'


### PR DESCRIPTION
This moves the polygon end / cancel buttons to the react ui and relies on events to trigger these actions. This makes it possible to use the polygon tool when using only the literally canvas core library.

|  | Old Tool UI | New Tool UI |
|---------|-------|-------|
| Tool Selected | <img width="318" alt="screen shot 2015-11-05 at 8 57 56 am" src="https://cloud.githubusercontent.com/assets/1527103/10970341/026d546c-839c-11e5-8e93-160accd2893e.png"> | <img width="318" alt="screen shot 2015-11-05 at 8 57 12 am" src="https://cloud.githubusercontent.com/assets/1527103/10970261/81df1bdc-839b-11e5-8572-092faa74eb5e.png"> |
| Shape in Progress | <img width="317" alt="screen shot 2015-11-05 at 8 58 08 am" src="https://cloud.githubusercontent.com/assets/1527103/10970303/cb400eb2-839b-11e5-90e5-34acddd7ebba.png"> | <img width="322" alt="screen shot 2015-11-05 at 8 57 33 am" src="https://cloud.githubusercontent.com/assets/1527103/10970309/d5f9e404-839b-11e5-9df4-ac62df73e877.png"> |



