### PR TITLE
Shape Selection And Move

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ v0.4.11:
  * Decouple polygon tool UI from tool; trigger 'lc-polygon*' events
  * Fixed several bugs in SVG rendering
  * Fixed behavior of stroke width picker when switching tools
+ * Add ability to programmatically select a shape & move it (no GUI yet)
 
 v0.4.10:
  * Fix the text tool

--- a/demo/core_demo.html
+++ b/demo/core_demo.html
@@ -15,7 +15,7 @@
       }
 
       .fs-container {
-       width: 768px;
+       width: 1000px;
        margin: 50px;
       }
 
@@ -99,6 +99,7 @@
         <a href="javascript:void(0);" class='tool' id="tool-ellipse">Ellipse</a>
         <a href="javascript:void(0);" class='tool' id="tool-rectangle">Rectangle</a>
         <a href="javascript:void(0);" class='tool' id="tool-polygon">Polygon</a>
+        <a href="javascript:void(0);" class='tool' id="tool-select">Select</a>
       </div>
 
 <!-- SIZES WON'T WORK UNTIL SIZE EVENT PR IS MERGED! -->
@@ -249,6 +250,10 @@
             name: 'tool-polygon',
             el: document.getElementById('tool-polygon'),
             tool: new LC.tools.Polygon(lc)
+          },{
+            name: 'tool-select',
+            el: document.getElementById('tool-select'),
+            tool: new LC.tools.SelectShape(lc)
           }
         ];
 

--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -299,13 +299,8 @@ module.exports = class LiterallyCanvas
   # without doing a full repaint.
   # The context is restored to its original state before returning.
   drawShapeInProgress: (shape) ->
+    @setShapesInProgress [shape]
     @repaintLayer('main', false)
-    @clipped (=>
-      @transformed (=>
-        renderShapeToContext(
-          @ctx, shape, {@bufferCtx, shouldOnlyDrawLatest: true})
-      ), @ctx, @bufferCtx
-    ), @ctx, @bufferCtx
 
   # Draws the given shapes translated and scaled to the given context.
   # The context is restored to its original state before returning.

--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -352,6 +352,7 @@ module.exports = class LiterallyCanvas
   clear: (triggerClearEvent=true) ->
     oldShapes = @shapes
     newShapes = []
+    @setShapesInProgress []
     @execute(new actions.ClearAction(this, oldShapes, newShapes))
     @repaintLayer('main')
     if triggerClearEvent

--- a/src/core/canvasRenderer.coffee
+++ b/src/core/canvasRenderer.coffee
@@ -69,6 +69,8 @@ defineCanvasRenderer 'Ellipse', (ctx, shape) ->
 
 defineCanvasRenderer 'SelectionBox', do ->
   _drawHandle = (ctx, {x, y}, handleSize) ->
+    return if handleSize == 0
+
     ctx.fillStyle = '#fff'
     ctx.fillRect(x, y, handleSize, handleSize)
     ctx.strokeStyle = '#000'

--- a/src/core/shapes.coffee
+++ b/src/core/shapes.coffee
@@ -24,7 +24,7 @@ defineShape = (name, props) ->
       legacyDrawFunc.call(shape, ctx, retryCallback)
     drawLatestFunc = (ctx, bufferCtx, shape, retryCallback) ->
       legacyDrawLatestFunc.call(shape, ctx, bufferCtx, retryCallback)
-    delete props.draw 
+    delete props.draw
     delete props.drawLatest if props.drawLatest
 
     defineCanvasRenderer(name, drawFunc, drawLatestFunc)
@@ -439,7 +439,10 @@ defineShape 'Text',
 defineShape 'SelectionBox',
   constructor: (args={}) ->
     @shape = args.shape
-    @handleSize = 10
+    if args.handleSize?
+      @handleSize = args.handleSize
+    else
+      @handleSize = 10
     @margin = 4
     @backgroundColor = args.backgroundColor or null
     @_br = @shape.getBoundingRect(args.ctx)

--- a/src/core/shapes.coffee
+++ b/src/core/shapes.coffee
@@ -132,6 +132,12 @@ defineShape 'Image',
       img = new Image()
       img.src = data.imageSrc
     createShape('Image', {x: data.x, y: data.y, image: img, scale: data.scale})
+  move: ( moveInfo={} ) ->
+    @x = @x - moveInfo.xDiff
+    @y = @y - moveInfo.yDiff
+  setUpperLeft: (upperLeft={}) ->
+    @x = upperLeft.x
+    @y = upperLeft.y
 
 
 defineShape 'Rectangle',
@@ -152,6 +158,12 @@ defineShape 'Rectangle',
   }
   toJSON: -> {@x, @y, @width, @height, @strokeWidth, @strokeColor, @fillColor}
   fromJSON: (data) -> createShape('Rectangle', data)
+  move: ( moveInfo={} ) ->
+    @x = @x - moveInfo.xDiff
+    @y = @y - moveInfo.yDiff
+  setUpperLeft: (upperLeft={}) ->
+    @x = upperLeft.x
+    @y = upperLeft.y
 
 
 # this is pretty similar to the Rectangle shape. maybe consolidate somehow.
@@ -173,6 +185,12 @@ defineShape 'Ellipse',
   }
   toJSON: -> {@x, @y, @width, @height, @strokeWidth, @strokeColor, @fillColor}
   fromJSON: (data) -> createShape('Ellipse', data)
+  move: ( moveInfo={} ) ->
+    @x = @x - moveInfo.xDiff
+    @y = @y - moveInfo.yDiff
+  setUpperLeft: (upperLeft={}) ->
+    @x = upperLeft.x
+    @y = upperLeft.y
 
 
 defineShape 'Line',
@@ -196,6 +214,16 @@ defineShape 'Line',
   toJSON: ->
     {@x1, @y1, @x2, @y2, @strokeWidth, @color, @capStyle, @dash, @endCapShapes}
   fromJSON: (data) -> createShape('Line', data)
+  move: ( moveInfo={} ) ->
+    @x1 = @x1 - moveInfo.xDiff
+    @y1 = @y1 - moveInfo.yDiff
+    @x2 = @x2 - moveInfo.xDiff
+    @y2 = @y2 - moveInfo.yDiff
+  setUpperLeft: (upperLeft={}) ->
+    br = @getBoundingRect()
+    xDiff = br.x - upperLeft.x
+    yDiff = br.y - upperLeft.y
+    @move({ xDiff, yDiff })
 
 
 # returns false if no points because there are no points to share style
@@ -306,6 +334,22 @@ linePathFuncs =
         0, @smoothedPoints.length - @segmentSize * (@tailSize - 1)
       ).concat(@tail)
 
+  move: ( moveInfo={} ) ->
+    if !@smooth
+      pts = @points
+    else
+      pts = @smoothedPoints
+
+    for pt in pts
+      pt.move(moveInfo)
+
+    @points = @smoothedPoints
+
+  setUpperLeft: (upperLeft={}) ->
+    br = @getBoundingRect()
+    xDiff = br.x - upperLeft.x
+    yDiff = br.y - upperLeft.y
+    @move({ xDiff, yDiff })
 
 LinePath = defineShape 'LinePath', linePathFuncs
 
@@ -330,6 +374,12 @@ defineShape 'Point',
     {x: @x - @size / 2, y: @y - @size / 2, width: @size, height: @size}
   toJSON: -> {@x, @y, @size, @color}
   fromJSON: (data) -> createShape('Point', data)
+  move: ( moveInfo={} ) ->
+    @x = @x - moveInfo.xDiff
+    @y = @y - moveInfo.yDiff
+  setUpperLeft: (upperLeft={}) ->
+    @x = upperLeft.x
+    @y = upperLeft.y
 
 
 defineShape 'Polygon',
@@ -365,6 +415,16 @@ defineShape 'Polygon',
         x, y, size: data.strokeWidth, color: data.strokeColor
       })
     createShape('Polygon', data)
+
+  move: ( moveInfo={} ) ->
+    for pt in @points
+      pt.move(moveInfo)
+
+  setUpperLeft: (upperLeft={}) ->
+    br = @getBoundingRect()
+    xDiff = br.x - upperLeft.x
+    yDiff = br.y - upperLeft.y
+    @move({ xDiff, yDiff })
 
 
 defineShape 'Text',
@@ -434,6 +494,12 @@ defineShape 'Text',
     }
   toJSON: -> {@x, @y, @text, @color, @font, @forcedWidth, @forcedHeight, @v}
   fromJSON: (data) -> createShape('Text', data)
+  move: ( moveInfo={} ) ->
+    @x = @x - moveInfo.xDiff
+    @y = @y - moveInfo.yDiff
+  setUpperLeft: (upperLeft={}) ->
+    @x = upperLeft.x
+    @y = upperLeft.y
 
 
 defineShape 'SelectionBox',

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -39,6 +39,7 @@ tools =
   Polygon: require './tools/Polygon'
   Pan: require './tools/Pan'
   Eyedropper: require './tools/Eyedropper'
+  SelectShape: require './tools/SelectShape'
 
   Tool: baseTools.Tool
   ToolWithStroke: baseTools.ToolWithStroke

--- a/src/tools/SelectShape.coffee
+++ b/src/tools/SelectShape.coffee
@@ -1,0 +1,102 @@
+{Tool} = require './base'
+{createShape} = require '../core/shapes'
+
+module.exports = class SelectShape extends Tool
+  name: 'SelectShape'
+  usesSimpleAPI: false
+
+  constructor: (lc) ->
+    # This is a 'shadow' canvas -- we'll reproduce the shapes here, each shape
+    # with a different color that corresponds to their index. That way we'll
+    # be able to find which shape to select on the main canvas by pixel color.
+    @selectCanvas = document.createElement('canvas')
+    @selectCanvas.style['background-color'] = 'transparent'
+    @selectCtx = @selectCanvas.getContext('2d')
+
+  didBecomeActive: (lc) ->
+    selectShapeUnsubscribeFuncs = []
+    @_selectShapeUnsubscribe = =>
+      for func in selectShapeUnsubscribeFuncs
+        func()
+
+    onDown = ({ x, y }) =>
+      @didDrag = false
+
+      shapeIndex = @_getPixel(x, y, lc, @selectCtx)
+      @selectedShape = lc.shapes[shapeIndex]
+
+      if @selectedShape?
+        lc.trigger 'SelectShapeed', { @selectedShape }
+        lc.setShapesInProgress [@selectedShape, createShape('SelectionBox', {
+          shape: @selectedShape,
+          handleSize: 0
+        })]
+        lc.repaintLayer 'main'
+
+        br = @selectedShape.getBoundingRect()
+        @dragOffset = {
+          x: x - br.x,
+          y: y - br.y
+        }
+
+    onDrag = ({ x, y }) =>
+      if @selectedShape?
+        @didDrag = true
+
+        @selectedShape.setUpperLeft {
+          x: x - @dragOffset.x,
+          y: y - @dragOffset.y
+        }
+        lc.setShapesInProgress [@selectedShape, createShape('SelectionBox', {
+          shape: @selectedShape,
+          handleSize: 0
+        })]
+        lc.repaintLayer 'main'
+
+    onUp = ({ x, y }) =>
+      if @didDrag
+        @didDrag = false
+        lc.trigger('shapeMoved', { shape: @selectedShape })
+        lc.trigger('drawingChange', {})
+        lc.repaintLayer('main')
+        @_drawSelectCanvas(lc)
+
+    selectShapeUnsubscribeFuncs.push lc.on 'lc-pointerdown', onDown
+    selectShapeUnsubscribeFuncs.push lc.on 'lc-pointerdrag', onDrag
+    selectShapeUnsubscribeFuncs.push lc.on 'lc-pointerup', onUp
+
+    @_drawSelectCanvas(lc)
+
+  willBecomeInactive: (lc) ->
+    @_selectShapeUnsubscribe()
+    lc.setShapesInProgress []
+
+  _drawSelectCanvas: (lc) ->
+    @selectCanvas.width = lc.canvas.width
+    @selectCanvas.height = lc.canvas.height
+    @selectCtx.clearRect(0, 0, @selectCanvas.width, @selectCanvas.height)
+    shapes = lc.shapes.map (shape, index) =>
+      createShape('SelectionBox', {
+        shape: shape,
+        handleSize: 0,
+        backgroundColor: "##{@_intToHex(index)}"
+      })
+    lc.draw(shapes, @selectCtx)
+
+  _intToHex: (i) ->
+    "000000#{i.toString 16}".slice(-6)
+
+  _getPixel: (x, y, lc, ctx) ->
+    p = lc.drawingCoordsToClientCoords x, y
+    pixel = ctx.getImageData(p.x, p.y, 1, 1).data
+    if pixel[3]
+      parseInt @_rgbToHex(pixel[0], pixel[1], pixel[2]), 16
+    else
+      null
+
+  _componentToHex: (c) ->
+    hex = c.toString(16);
+    "0#{hex}".slice -2
+
+  _rgbToHex: (r, g, b) ->
+    "#{@_componentToHex(r)}#{@_componentToHex(g)}#{@_componentToHex(b)}"


### PR DESCRIPTION
Connects to #246 

![core-demo-select](https://cloud.githubusercontent.com/assets/1527103/11858832/2fc62594-a433-11e5-9daa-5194fee913ba.gif)

This PR adds the ability to select and move a shape (no ReactGUI for it yet, so I've only added it to the core demo page). 

Some things: 
  - This is not currently an undoable action. It would be good to make this an action in the future, but not for every step of the way, just start and end.
  - I'm currently using the bounding rectangle as the 'select area' for each shape. I like this because for the whiteboard application that I'm working on we want something simple and this way you don't have to get fiddly with little bits to select something and move it out of the way. An earlier implementation was closer to shape outlines, so if you had transparent shapes you could select what's underneath them by clicking the visible bits, etc, by having each shape draw itself exactly on the select canvas (but in the proper color). I don't know which way we want the main library to go though, so let me know if the bounding rectangle select area isn't ok for now :)