### PR TITLE
Added triggerClearEvent to clear function

### DIFF
--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -354,12 +354,13 @@ module.exports = class LiterallyCanvas
     for ctx in contexts
       ctx.restore()
 
-  clear: ->
+  clear: (triggerClearEvent=true) ->
     oldShapes = @shapes
     newShapes = []
     @execute(new actions.ClearAction(this, oldShapes, newShapes))
     @repaintLayer('main')
-    @trigger('clear', null)
+    if triggerClearEvent
+      @trigger('clear', null)
     @trigger('drawingChange', {})
 
   execute: (action) ->


### PR DESCRIPTION
Hi! Thanks for the great project.

When networking the clear event in my application, I encountered an infinite loop. (client sending clear → other client clearing, and then networking that clear back, and so on) So I needed this option to stop this from happening.

Adding this simple if-clause fixed the problem in my application. Like the `triggerShapeSaveEvent` when using `saveShape` prevents the same issue.