### PR TITLE
Make a commonJS build for npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 literallycanvas/
 *.sublime-workspace
 node_modules/
+*.log

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ release-bower:
 	git push lc-bower release:master -f
 	git push lc-bower --tags
 
+release-npm:
+	npm publish
+
 ignore-js:
 	git update-index --assume-unchanged lib/js/literallycanvas.js
 	git update-index --assume-unchanged lib/js/literallycanvas.min.js

--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "literallycanvas",
   "version": "0.4.11",
   "description": "HTML5 drawing widget",
-  "main": "index.js",
+  "main": "lib/js",
   "scripts": {
+    "coffee": "coffee --compile --bare --output lib/js/ src/",
+    "prepublish": "npm run coffee",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -22,7 +24,8 @@
   },
   "devDependencies": {
     "browserify": "~3.44.2",
-    "coffeeify": "~0.6.0",
+    "coffee-script": "^1.10.0",
+    "coffeeify": "^2.0.1",
     "envify": "~1.2.1",
     "gulp": "~3.8.0",
     "gulp-connect": "~2.0.5",

--- a/src/core/svgRenderer.coffee
+++ b/src/core/svgRenderer.coffee
@@ -4,7 +4,7 @@ renderers = {}
 
 # shapeToSVG(shape) -> string
 defineSVGRenderer = (shapeName, shapeToSVGFunc) ->
-	renderers[shapeName] = shapeToSVGFunc
+  renderers[shapeName] = shapeToSVGFunc
 
 
 renderShapeToSVG = (shape, opts={}) ->
@@ -108,7 +108,7 @@ defineSVGRenderer 'LinePath', (shape) ->
       points='#{shape.smoothedPoints.map((p) ->
         offset = if p.strokeWidth % 2 == 0 then 0.0 else 0.5
         "#{p.x+offset},#{p.y+offset}").join(' ')
-      }'
+}'
       stroke='#{shape.points[0].color}'
       stroke-linecap='round'
       stroke-width='#{shape.points[0].size}' />
@@ -127,7 +127,7 @@ defineSVGRenderer 'Polygon', (shape) ->
         points='#{shape.points.map((p) ->
           offset = if p.strokeWidth % 2 == 0 then 0.0 else 0.5
           "#{p.x+offset},#{p.y+offset}").join(' ')
-        }'
+}'
         stroke='#{shape.strokeColor}'
         stroke-width='#{shape.strokeWidth}' />
     "
@@ -138,14 +138,14 @@ defineSVGRenderer 'Polygon', (shape) ->
         points='#{shape.points.map((p) ->
           offset = if p.strokeWidth % 2 == 0 then 0.0 else 0.5
           "#{p.x+offset},#{p.y+offset}").join(' ')
-        }'
+}'
         stroke='none' />
       <polyline
         fill='none'
         points='#{shape.points.map((p) ->
           offset = if p.strokeWidth % 2 == 0 then 0.0 else 0.5
           "#{p.x+offset},#{p.y+offset}").join(' ')
-        }'
+}'
         stroke='#{shape.strokeColor}'
         stroke-width='#{shape.strokeWidth}' />
     "


### PR DESCRIPTION
See #230 

A couple notes:

- When using the latest `coffeify` or `coffee-script` CLI tool I got warnings about indentation (even after checking line encoding and spaces/tabs), and changing the spacing on `'}'` strings fixed it.
- Running `npm publish` will first compile the Coffeescript into CommonJS javascript
- I updated the `main` section of `package.json` to point to the CommonJS entry point, so people using npm with Browserify/Webpack can `require()` the library easily
- The order of operations for releasing a build could be important here since the `lib/js` folder is being used for both CommonJS output *and* the Browserified output from Gulp. Just make sure you treat `make` and `make release-files` as a single atomic operation and don't do a `npm publish` in between them.