### PR TITLE
Fix undefined variable typo

### DIFF
--- a/src/core/TextRenderer.coffee
+++ b/src/core/TextRenderer.coffee
@@ -94,7 +94,7 @@ class TextRenderer
     @emDashWidth = ctx.measureTextWidth('—', fontSize, fontFamily).width
     @caratWidth = ctx.measureTextWidth('|', fontSize, fontFamily).width
 
-    @lines = getLinesToRender(ctx, text, @forcedWidth)
+    @lines = getLinesToRender(ctx, @text, @forcedWidth)
 
     # we need to get metrics line by line and combine them. :-(
     @metricses = @lines.map (line) =>


### PR DESCRIPTION
Currently getting the following Error when trying to draw text:

```
Uncaught ReferenceError: text is not defined
```

This PR fixes the typo.

@irskep 