### PR TITLE
Fix errors rendering children of input tag

### DIFF
--- a/scss/literallycanvas.scss
+++ b/scss/literallycanvas.scss
@@ -236,7 +236,7 @@ $selectedColor: lighten(#3cb0fd, 20%);
   height: $optionsHeight;
   background-color: $toolbarBackground;
 
-  label {
+  span {
     line-height: $optionsHeight - 1px;
     margin: 0 0.25em 0 0.25em;
     font-size: 12px;

--- a/src/optionsStyles/font.coffee
+++ b/src/optionsStyles/font.coffee
@@ -121,26 +121,26 @@ defineOptionsStyle 'font', React.createClass
             (option {value: family.name, key: ix}, family.name)
           )
       )
-      (label {htmlFor: 'italic'},
+      (span {},
+        (label {htmlFor: 'italic'}, _("italic")),
         (input \
           {
             type: 'checkbox',
             id: 'italic',
             checked: @state.isItalic,
             onChange: @handleItalic
-          },
-          _("italic")
+          }
         )
       )
-      (label {htmlFor: 'bold'},
+      (span {},
+        (label {htmlFor: 'bold'}, _("bold")),
         (input \
           {
             type: 'checkbox',
             id: 'bold',
             checked: @state.isBold,
             onChange: @handleBold,
-          },
-          _("bold")
+          }
         )
       )
     )


### PR DESCRIPTION
Currently there are Errors thrown when rendering the options for the Font tool because there are (illegal) children of an `<input>` tag:

![screen shot 2016-01-14 at 2 14 36 pm](https://cloud.githubusercontent.com/assets/635005/12339859/3290fe02-bacc-11e5-858d-aa1494afc1ef.png)

This PR fixes the errors. @irskep 