### PR TITLE
Fix undefined pointer on pointer move

### DIFF
--- a/src/core/LiterallyCanvas.coffee
+++ b/src/core/LiterallyCanvas.coffee
@@ -138,7 +138,7 @@ module.exports = class LiterallyCanvas
   pointerMove: (x, y) ->
     util.requestAnimationFrame () =>
       p = @clientCoordsToDrawingCoords(x, y)
-      if @tool.usesSimpleAPI
+      if @tool?.usesSimpleAPI
         if @isDragging
           @tool.continue p.x, p.y, this
           @trigger("drawContinue", {tool: @tool})


### PR DESCRIPTION
Occasionally, after unmounting/teardown, the `pointerMove` function still fires one more time, at which point `this.tool` is undefined.

Adding an additional check makes sure no Error is thrown in this specific case.

@irskep 