### PR TITLE
Fix exception when there is no color to pick

### DIFF
--- a/src/reactGUI/ColorWell.coffee
+++ b/src/reactGUI/ColorWell.coffee
@@ -5,7 +5,7 @@ PureRenderMixin = require 'react-addons-pure-render-mixin'
 
 parseHSLAString = (s) ->
   return {hue: 0, sat: 0, light: 0, alpha: 0} if s == 'transparent'
-  return null unless s.substring(0, 4) == 'hsla'
+  return null unless s?.substring(0, 4) == 'hsla'
   firstParen = s.indexOf('(')
   lastParen = s.indexOf(')')
   insideParens = s.substring(firstParen + 1, lastParen - firstParen + 4)


### PR DESCRIPTION
Fix "TypeError: Cannot read property 'substring' of null" when trying to use the color picker over an area with no color and only a background image.