### PR TITLE
Change requestAnimationFrame precedence

### DIFF
--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -136,15 +136,15 @@ util =
         s4() + s4() + s4())
 
   requestAnimationFrame: (f) ->
-    return window.webkitRequestAnimationFrame(f) if window.webkitRequestAnimationFrame
     return window.requestAnimationFrame(f) if window.requestAnimationFrame
+    return window.webkitRequestAnimationFrame(f) if window.webkitRequestAnimationFrame
     return window.mozRequestAnimationFrame(f) if window.mozRequestAnimationFrame
     return setTimeout(f, 0)
 
   cancelAnimationFrame: (f) ->
+    return window.cancelAnimationFrame(f) if window.cancelAnimationFrame
     return window.webkitCancelRequestAnimationFrame(f) if window.webkitCancelRequestAnimationFrame
     return window.webkitCancelAnimationFrame(f) if window.webkitCancelAnimationFrame
-    return window.cancelAnimationFrame(f) if window.cancelAnimationFrame
     return window.mozCancelAnimationFrame(f) if window.mozCancelAnimationFrame
     return clearTimeout(f)
 


### PR DESCRIPTION
Try to use requestAnimationFrame before looking at the vendor prefix variants.

Fixes this warning in Chrome:

> 'webkitRequestAnimationFrame' is vendor-specific. Please use the standard 'requestAnimationFrame' instead.