### PR TITLE
Pass width and height to drawImage when scale is 1.

### DIFF
--- a/src/core/canvasRenderer.coffee
+++ b/src/core/canvasRenderer.coffee
@@ -102,7 +102,7 @@ defineCanvasRenderer 'SelectionBox', do ->
 defineCanvasRenderer 'Image', (ctx, shape, retryCallback) ->
   if shape.image.width
     if shape.scale == 1
-      ctx.drawImage(shape.image, shape.x, shape.y)
+      ctx.drawImage(shape.image, shape.x, shape.y, shape.image.width, shape.image.height)
     else
       ctx.drawImage(
         shape.image, shape.x, shape.y,


### PR DESCRIPTION
I wouldn't like to use scale but I would like to provide my own image dimensions (width and height) to drawImage() for image resizing when I'm using createShape().

Is there another way to specify the desired width and height for my image and have it reduced or enlarged to that size? The existing setImageSize() doesn't seem to actually scale the entire image.

The patch that I provided allows me to scale the image to the dimensions I want:
```
my_image.height = 100;
my_image.width = 100;
LC.createShape('Image', {x: 0, y: 0, image: my_image, scale: 1});
```
