### PR TITLE
Fix rendering of Line to svg

### DIFF
--- a/src/core/svgRenderer.coffee
+++ b/src/core/svgRenderer.coffee
@@ -95,7 +95,7 @@ defineSVGRenderer 'Line', (shape) ->
       <line x1='#{x1}' y1='#{y1}' x2='#{x2}' y2='#{y2}'
         #{dashString}
         stroke-linecap='#{shape.capStyle}'
-        stroke='#{shape.color} 'stroke-width='#{shape.strokeWidth}' />
+        stroke='#{shape.color}' stroke-width='#{shape.strokeWidth}' />
       #{capString}
     </g>
   "


### PR DESCRIPTION
The closing quote of the stroke attribute for the Line element had no space between it as the next element, stroke-width.  This was causing the SVG to be malformed.

Example of incorrect output:

`<line x1='8.63157894736835' y1='8.63157894736835' x2='19.94736842105256' y2='8.894736842105191' stroke-linecap='round' stroke='hsla(120, 100%, 42%, 1) 'stroke-width='2' />`

Need to change `1) 'str` to `1)' str` as the space is in the wrong spot.

This commit fixes the spacing between the stroke and stroke-width attributes when rendering a Line.