### PR TITLE
Make sure <LiterallyCanvas> and initWithoutGUI() both respect opts.im…

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -81,6 +81,9 @@ initWithoutGUI = (el, opts) ->
   if el.className.includes('toolbar-hidden') == false
     el.className = el.className + ' toolbar-hidden'
 
+  if ('imageSize' of opts && 'height' of opts.imageSize)
+    el.style.height = opts.imageSize.height + 'px'
+
   drawingViewElement = document.createElement('div')
   drawingViewElement.className = 'lc-drawing'
   el.appendChild(drawingViewElement)

--- a/src/reactGUI/LiterallyCanvas.jsx
+++ b/src/reactGUI/LiterallyCanvas.jsx
@@ -70,7 +70,7 @@ const LiterallyCanvas = React.createClass({
 
   render() {
     const { lc, toolButtonComponents, props } = this;
-    const { imageURLPrefix, toolbarPosition } = this.lc.opts;
+    const { imageURLPrefix, toolbarPosition, imageSize } = this.lc.opts;
     
     const pickerProps = { lc, toolButtonComponents, imageURLPrefix };
     const topOrBottomClassName = classSet({
@@ -78,8 +78,13 @@ const LiterallyCanvas = React.createClass({
       'toolbar-at-bottom': toolbarPosition === 'bottom',
       'toolbar-hidden': toolbarPosition === 'hidden'
     });
+
+    const style = {}
+    if (imageSize.height)
+      style.height = imageSize.height
+
     return (
-      <div className={`literally ${topOrBottomClassName}`}>
+      <div className={`literally ${topOrBottomClassName}`} style={style}>
         <CanvasContainer ref={item => this.canvas = item} />
         <Picker {...pickerProps} />
         <Options lc={lc} imageURLPrefix={imageURLPrefix} />


### PR DESCRIPTION
Makes sure opts.imageSize.height is respected on reactGUI and non-gui mode.
fixes literallycanvas/literallycanvas#405
fixes literallycanvas/literallycanvas#424
fixes literallycanvas/literallycanvas#433