### PR TITLE
Add the ability to redo/undo moving a shape

### DIFF
--- a/src/core/actions.coffee
+++ b/src/core/actions.coffee
@@ -13,6 +13,25 @@ class ClearAction
     @lc.repaintLayer('main')
 
 
+class MoveAction
+
+  constructor: (@lc, @selectedShape, @previousPosition, @newPosition) ->
+
+  do: ->
+    @selectedShape.setUpperLeft {
+      x: @newPosition.x,
+      y: @newPosition.y
+    }
+    @lc.repaintLayer('main')
+
+  undo: ->
+    @selectedShape.setUpperLeft {
+      x: @previousPosition.x,
+      y: @previousPosition.y
+    }
+    @lc.repaintLayer('main')
+
+
 class AddShapeAction
 
   constructor: (@lc, @shape, @previousShapeId=null) ->
@@ -51,4 +70,4 @@ class AddShapeAction
     @lc.repaintLayer('main')
 
 
-module.exports = {ClearAction, AddShapeAction}
+module.exports = {ClearAction, MoveAction, AddShapeAction}

--- a/src/tools/SelectShape.coffee
+++ b/src/tools/SelectShape.coffee
@@ -1,3 +1,4 @@
+actions = require '../core/actions'
 {Tool} = require './base'
 {createShape} = require '../core/shapes'
 
@@ -38,6 +39,10 @@ module.exports = class SelectShape extends Tool
           x: x - br.x,
           y: y - br.y
         }
+        @initialPosition = {
+          x: br.x,
+          y: br.y
+        }
 
     onDrag = ({ x, y }) =>
       if @selectedShape?
@@ -56,6 +61,18 @@ module.exports = class SelectShape extends Tool
     onUp = ({ x, y }) =>
       if @didDrag
         @didDrag = false
+
+        # get the current position
+        br = @selectedShape.getBoundingRect()
+
+        newPosition = {
+          x: br.x,
+          y: br.y
+        }
+
+        # and add a move action
+        lc.execute(new actions.MoveAction(lc, @selectedShape, @initialPosition, newPosition))
+
         lc.trigger('shapeMoved', { shape: @selectedShape })
         lc.trigger('drawingChange', {})
         lc.repaintLayer('main')


### PR DESCRIPTION
I implemented a MoveAction and added the call to @lc.execute in the SelectShape Tools onUp method.

The SelectShape Tool already has the ability to select a shape and move it around the canvas.
It now also adds this as an action into the undo stack.