### PR TITLE
Fix TypeError: can't assign to property

### DIFF
--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -73,7 +73,7 @@ util =
         <rect width='#{width}' height='#{height}' x='0' y='0'
           fill='#{backgroundColor}' />
         <g transform='translate(#{-x}, #{-y})'>
-          #{shapes.map(renderShapeToSVG).join('')}
+          #{shapes.map((shape) -> renderShapeToSVG(shape)).join('')}
         </g>
       </svg>
     ".replace(/(\r\n|\n|\r)/gm,"")


### PR DESCRIPTION
```
TypeError: can't assign to property "shouldIgnoreUnsupportedShapes" on 0: not an object
```

`renderShapesToSVG()` that generates SVG uses `shapes.map(renderShapeToSVG)`, but `Array.map()` passes index (number) by default as a second argument.

Problem is that 2nd parameter of `renderShapeToSVG(shape, opts)` should be either omitted or an `Object`, therefor number produces `TypeError`.