### PR TITLE
Allow canvas images to respect the cross-origin attribute

### DIFF
--- a/src/core/shapes.coffee
+++ b/src/core/shapes.coffee
@@ -122,9 +122,14 @@ defineShape 'Image',
     @y = args.y or 0
     @scale = args.scale or 1
     @image = args.image or null
+    @crossOrigin = (args.image and args.image.crossOrigin) or null
   getBoundingRect: ->
     {@x, @y, width: @image.width * @scale, height: @image.height * @scale}
-  toJSON: -> {@x, @y, imageSrc: @image.src, imageObject: @image, @scale}
+  toJSON: () ->
+    toJSONData = {@x, @y, imageSrc: @image.src, imageObject: @image, @scale}
+    if @crossOrigin
+      toJSONData['crossOrigin'] = @crossOrigin
+    return toJSONData
   fromJSON: (data) ->
     img = null
     if data.imageObject?.width
@@ -132,6 +137,8 @@ defineShape 'Image',
     else
       img = new Image()
       img.src = data.imageSrc
+      if data.crossOrigin
+        img.crossOrigin = data.crossOrigin
     createShape('Image', {x: data.x, y: data.y, image: img, scale: data.scale})
   move: ( moveInfo={} ) ->
     @x = @x - moveInfo.xDiff


### PR DESCRIPTION
Currently, if a canvas image is hosted on a different server/host from
which the canvas is served, a security error will be thrown by
the browser. The change made will respect the cross-origin
attribute if its set on the image.

This is a sample of how I set the cross-origin attribute:
```
let backgroundImage = new Image();
backgroundImage.crossOrigin = 'Anonymous';
...
defaultOptions.backgroundShapes = [
    createShape('Image', {x: 0, y: 0, image: backgroundImage, scale: 1})
];
```
I've tested this with images that require the cross-origin attribute set and with images that don't because they're being served from the same host as the canvas, and my changes work in both cases.